### PR TITLE
Release 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsecurity/sdk",
-  "version": "0.8.1",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "SDK for the Socket API client",
   "author": {


### PR DESCRIPTION
Publishing v0.9.0 fails with the error `You cannot publish over the previously published versions: 0.7.3`, even though the latest version is 0.8.3 🤔 

Reading through similar issues in the community, it seems like a potential fix would be to bump a patch version.