### PR TITLE
chore: fix unsupported node version error

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -19,7 +19,6 @@ jobs:
          node-version: '18'
          registry-url: 'https://registry.npmjs.org'
          cache: npm
-     - run: npm install -g npm@latest
      - run: npm install
      - run: npm publish --provenance --access public
        env:


### PR DESCRIPTION
Provenance action fails due to npm `v11` not supporting Node `v18`.
https://github.com/SocketDev/socket-sdk-js/actions/runs/12610010279/job/35144125382#step:4:1