### PR TITLE
Move getOrgFullScan to streamOrgFullScan and getOrgFullScanBuffered

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,7 @@ class SocketSdk {
   async getOrgFullScan (
     orgSlug: string,
     fullScanId: string,
-    file?: string | false // When `false`, just .get rather than .stream
+    file?: string
   ) { return this.streamOrgFullScan(orgSlug, fullScanId, file) }
 
   /**


### PR DESCRIPTION
The `getOrgFullScan` is a bit of a misnomer, especially since the rest doesn't stream the data.

I'm moving the method to `streamOrgFullScan` and deprecating the old method.

Additionally, adding a new method `getOrgFullScanBuffere`, which should make the distinction clear and not risk a sort of rug pull.

We deprecate the old method and in some major we can complete the swap, or just drop it and leave it like this.