### PR TITLE
Destroy request before throwing an error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ async function createDeleteRequest(
   })
   const { 0: res } = (await events.once(req, 'response')) as [IncomingMessage]
   if (!isResponseOk(res)) {
+    req.destroy()
     throw new ResponseError(res, 'Delete request failed')
   }
   return res
@@ -91,6 +92,7 @@ async function createGetRequest(
     .end()
   const { 0: res } = (await events.once(req, 'response')) as [IncomingMessage]
   if (!isResponseOk(res)) {
+    req.destroy()
     throw new ResponseError(res, 'Get request failed')
   }
   return res
@@ -110,6 +112,7 @@ async function createPostRequest(
     .end(JSON.stringify(postJson))
   const { 0: res } = (await events.once(req, 'response')) as [IncomingMessage]
   if (!isResponseOk(res)) {
+    req.destroy()
     throw new ResponseError(res, 'Post request failed')
   }
   return res


### PR DESCRIPTION
When a request fails and an error is thrown, we must first destroy() the request instance for otherwise it will keep node alive, leading to hard-to-track stuck issues.

It seems non-errors don't have this problem and naturally end, so I'm only doing this in the error path.