### PR TITLE
feat(telemetry): adding telemetry endpoints

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "description": "Specification of the Socket API endpoints",
     "title": "API Endpoints",
-    "version": "0.1.0"
+    "version": "0"
   },
   "servers": [
     {
@@ -22,6 +22,9 @@
     },
     {
       "name": "Full Scans"
+    },
+    {
+      "name": "Fixes"
     },
     {
       "name": "Diff Scans"
@@ -57,10 +60,16 @@
       "name": "API Tokens"
     },
     {
+      "name": "Webhooks"
+    },
+    {
       "name": "Metadata"
     },
     {
       "name": "Deprecated"
+    },
+    {
+      "name": "Telemetry"
     }
   ],
   "components": {
@@ -373,6 +382,25 @@
               "_type",
               "value"
             ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "_type": {
+                "type": "string",
+                "enum": [
+                  "summary"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/PurlSummarySchema"
+              }
+            },
+            "required": [
+              "_type",
+              "value"
+            ]
           }
         ]
       },
@@ -435,6 +463,9 @@
               },
               "score": {
                 "$ref": "#/components/schemas/SocketScore"
+              },
+              "patch": {
+                "$ref": "#/components/schemas/SocketArtifactPatch"
               },
               "inputPurl": {
                 "type": "string",
@@ -1247,6 +1278,16 @@
             "description": "",
             "nullable": true
           },
+          "deny": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "",
+              "default": ""
+            },
+            "description": "",
+            "nullable": true
+          },
           "options": {
             "type": "array",
             "items": {
@@ -1260,6 +1301,7 @@
         },
         "required": [
           "allow",
+          "deny",
           "monitor",
           "options",
           "warn"
@@ -1573,6 +1615,49 @@
           "inputPurl"
         ]
       },
+      "PurlSummarySchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "",
+        "properties": {
+          "purl_input": {
+            "type": "integer",
+            "description": "",
+            "default": 0
+          },
+          "resolved": {
+            "type": "integer",
+            "description": "",
+            "default": 0
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "",
+            "properties": {
+              "purl_malformed": {
+                "type": "integer",
+                "description": "",
+                "default": 0
+              },
+              "package_not_found": {
+                "type": "integer",
+                "description": "",
+                "default": 0
+              }
+            },
+            "required": [
+              "package_not_found",
+              "purl_malformed"
+            ]
+          }
+        },
+        "required": [
+          "errors",
+          "purl_input",
+          "resolved"
+        ]
+      },
       "SocketBatchPURLRequest": {
         "type": "object",
         "additionalProperties": false,
@@ -1731,7 +1816,6 @@
           "fix": {
             "type": "object",
             "additionalProperties": false,
-            "description": "",
             "properties": {
               "type": {
                 "type": "string",
@@ -1742,12 +1826,48 @@
                 "type": "string",
                 "description": "Human-readable description of how to fix this issue",
                 "default": ""
+              },
+              "patch": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "description": "Unique identifier for this patch",
+                      "default": ""
+                    },
+                    "tier": {
+                      "type": "string",
+                      "enum": [
+                        "free",
+                        "paid"
+                      ],
+                      "description": "Access tier required for this patch (free or paid)",
+                      "default": "free"
+                    },
+                    "deprecated": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Indicates if this patch is deprecated and should not be used"
+                    }
+                  },
+                  "required": [
+                    "tier",
+                    "uuid"
+                  ]
+                },
+                "description": "Patches available to fix this specific alert"
               }
             },
             "required": [
               "description",
               "type"
             ]
+          },
+          "patch": {
+            "$ref": "#/components/schemas/SocketPatch"
           },
           "reachability": {
             "type": "object",
@@ -1761,12 +1881,34 @@
               }
             },
             "description": ""
+          },
+          "subType": {
+            "type": "string",
+            "description": "Generic alert sub-type",
+            "default": ""
           }
         },
         "required": [
           "key",
           "type"
         ]
+      },
+      "SocketArtifactPatch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "appliedPatch": {
+            "$ref": "#/components/schemas/SocketPatch"
+          },
+          "availablePatches": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SocketPatch"
+            },
+            "description": "List of available patches that can be applied to fix vulnerabilities"
+          }
+        },
+        "description": ""
       },
       "LicenseDetails": {
         "type": "array",
@@ -4324,6 +4466,482 @@
                         "required": [
                           "description",
                           "title"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ghaArgToSink"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
+                          "sourceLocation": {
+                            "type": "object",
+                            "description": "",
+                            "default": null
+                          },
+                          "sinkLocations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "description": "",
+                              "default": null
+                            },
+                            "description": ""
+                          }
+                        },
+                        "required": [
+                          "message",
+                          "sinkLocations",
+                          "sourceLocation"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ghaEnvToSink"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
+                          "sourceLocation": {
+                            "type": "object",
+                            "description": "",
+                            "default": null
+                          },
+                          "sinkLocations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "description": "",
+                              "default": null
+                            },
+                            "description": ""
+                          }
+                        },
+                        "required": [
+                          "message",
+                          "sinkLocations",
+                          "sourceLocation"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ghaContextToSink"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
+                          "sourceLocation": {
+                            "type": "object",
+                            "description": "",
+                            "default": null
+                          },
+                          "sinkLocations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "description": "",
+                              "default": null
+                            },
+                            "description": ""
+                          }
+                        },
+                        "required": [
+                          "message",
+                          "sinkLocations",
+                          "sourceLocation"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ghaArgToOutput"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
+                          "sourceLocation": {
+                            "type": "object",
+                            "description": "",
+                            "default": null
+                          },
+                          "sinkLocations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "description": "",
+                              "default": null
+                            },
+                            "description": ""
+                          }
+                        },
+                        "required": [
+                          "message",
+                          "sinkLocations",
+                          "sourceLocation"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ghaArgToEnv"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
+                          "sourceLocation": {
+                            "type": "object",
+                            "description": "",
+                            "default": null
+                          },
+                          "sinkLocations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "description": "",
+                              "default": null
+                            },
+                            "description": ""
+                          }
+                        },
+                        "required": [
+                          "message",
+                          "sinkLocations",
+                          "sourceLocation"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ghaContextToOutput"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
+                          "sourceLocation": {
+                            "type": "object",
+                            "description": "",
+                            "default": null
+                          },
+                          "sinkLocations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "description": "",
+                              "default": null
+                            },
+                            "description": ""
+                          }
+                        },
+                        "required": [
+                          "message",
+                          "sinkLocations",
+                          "sourceLocation"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ghaContextToEnv"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "message": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
+                          "sourceLocation": {
+                            "type": "object",
+                            "description": "",
+                            "default": null
+                          },
+                          "sinkLocations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "description": "",
+                              "default": null
+                            },
+                            "description": ""
+                          }
+                        },
+                        "required": [
+                          "message",
+                          "sinkLocations",
+                          "sourceLocation"
                         ]
                       },
                       "usage": {
@@ -8673,6 +9291,456 @@
                 ]
               }
             }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsxProposedApiUsage"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "proposals": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          }
+                        },
+                        "required": [
+                          "proposals"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsxActivationWildcard"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "event": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          }
+                        },
+                        "required": [
+                          "event"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsxWorkspaceContainsActivation"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "pattern": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          }
+                        },
+                        "required": [
+                          "pattern"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsxUntrustedWorkspaceSupported"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "supported": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          }
+                        },
+                        "required": [
+                          "supported"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsxVirtualWorkspaceSupported"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "supported": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          }
+                        },
+                        "required": [
+                          "supported"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsxWebviewContribution"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {}
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsxDebuggerContribution"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {}
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsxExtensionDependency"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "extension": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          }
+                        },
+                        "required": [
+                          "extension"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vsxExtensionPack"
+                ]
+              },
+              "value": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SocketIssueBasics"
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "count": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          }
+                        },
+                        "required": [
+                          "count"
+                        ]
+                      },
+                      "usage": {
+                        "$ref": "#/components/schemas/SocketUsageRef"
+                      }
+                    },
+                    "required": [
+                      "description",
+                      "props"
+                    ]
+                  }
+                ]
+              }
+            }
           }
         ]
       },
@@ -8712,6 +9780,7 @@
       "SocketPURL_Type": {
         "type": "string",
         "enum": [
+          "alpm",
           "apk",
           "bitbucket",
           "cocoapods",
@@ -8741,6 +9810,7 @@
           "rpm",
           "swid",
           "swift",
+          "vscode",
           "unknown"
         ],
         "description": "Package ecosystem type identifier based on the PURL specification",
@@ -8769,6 +9839,35 @@
         ],
         "description": "",
         "default": "other"
+      },
+      "SocketPatch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "description": "Unique identifier for this patch",
+            "default": ""
+          },
+          "tier": {
+            "type": "string",
+            "enum": [
+              "free",
+              "paid"
+            ],
+            "description": "Access tier required for this patch (free or paid)",
+            "default": "free"
+          },
+          "deprecated": {
+            "type": "boolean",
+            "default": false,
+            "description": "Indicates if this patch is deprecated and should not be used"
+          }
+        },
+        "required": [
+          "tier",
+          "uuid"
+        ]
       },
       "ReachabilityResult": {
         "type": "object",
@@ -9485,6 +10584,26 @@
               "type": "boolean",
               "default": false
             }
+          },
+          {
+            "name": "cachedResultsOnly",
+            "in": "query",
+            "required": false,
+            "description": "Return only cached results, do not attempt to scan new artifacts or rescan stale results.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "summary",
+            "in": "query",
+            "required": false,
+            "description": "Include a summary object at the end of the stream with counts of malformed, resolved, and not found PURLs.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "requestBody": {
@@ -9912,7 +11031,7 @@
             "name": "page",
             "in": "query",
             "required": false,
-            "description": "The token specifying which page to return.",
+            "description": "The page number to return when using offset-style pagination. Ignored when cursor pagination is used.",
             "schema": {
               "type": "integer",
               "minimum": 1,
@@ -9920,10 +11039,38 @@
             }
           },
           {
+            "name": "startAfterCursor",
+            "in": "query",
+            "required": false,
+            "description": "Cursor token for pagination. Pass the returned nextPageCursor from previous responses to fetch the next set of results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "use_cursor",
+            "in": "query",
+            "required": false,
+            "description": "Set to true on the first request to opt into cursor-based pagination.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
             "name": "from",
             "in": "query",
             "required": false,
             "description": "A Unix timestamp in seconds that filters full-scans prior to the date.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "description": "A repository workspace to filter full-scans by.",
             "schema": {
               "type": "string"
             }
@@ -10073,6 +11220,11 @@
                             "default": "",
                             "nullable": true
                           },
+                          "workspace": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
                           "repo": {
                             "type": "string",
                             "description": "",
@@ -10129,6 +11281,12 @@
                       },
                       "description": ""
                     },
+                    "nextPageCursor": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
                     "nextPage": {
                       "type": "integer",
                       "description": "",
@@ -10138,6 +11296,7 @@
                   },
                   "required": [
                     "nextPage",
+                    "nextPageCursor",
                     "results"
                   ]
                 }
@@ -10189,6 +11348,15 @@
             }
           },
           {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "description": "The workspace of the repository to associate the full-scan with.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "branch",
             "in": "query",
             "required": false,
@@ -10229,7 +11397,7 @@
             "name": "committers",
             "in": "query",
             "required": false,
-            "description": "The committers to associate the full-scan with. Set query more than once to set multiple.",
+            "description": "The committers to associate with the full-scan. Set query more than once to set multiple.",
             "schema": {
               "type": "string"
             }
@@ -10288,6 +11456,16 @@
               "type": "boolean",
               "default": false
             }
+          },
+          {
+            "name": "scan_type",
+            "in": "query",
+            "required": false,
+            "description": "The type of scan to perform. Defaults to 'socket'. Must be 32 characters or less. Used for categorizing multiple SBOM heads per repository branch.",
+            "schema": {
+              "type": "string",
+              "default": "socket"
+            }
           }
         ],
         "requestBody": {
@@ -10323,7 +11501,7 @@
             ]
           }
         ],
-        "description": "Create a full scan from a set of package manifest files. Returns a full scan including all SBOM artifacts.\n\nTo get a list of supported filetypes that can be uploaded in a full-scan, see the [Get supported file types](/reference/getsupportedfiles) endpoint.\n\nThe maximum number of files you can upload at a time is 5000 and each file can be no bigger than 67 MB.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- full-scans:create",
+        "description": "Create a full scan from a set of package manifest files. Returns a full scan including all SBOM artifacts.\n\nTo get a list of supported filetypes that can be uploaded in a full-scan, see the [Get supported file types](/reference/getsupportedfiles) endpoint.\n\nThe maximum number of files you can upload at a time is 5000 and each file can be no bigger than 67 MB.\n\n**Query Parameters:**\n- `scan_type` (optional): The type of scan to perform. Defaults to 'socket'. Must be 32 characters or less. Used for categorizing multiple SBOM heads per repository branch.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- full-scans:create",
         "responses": {
           "201": {
             "content": {
@@ -10411,6 +11589,11 @@
                       "description": "",
                       "default": "",
                       "nullable": true
+                    },
+                    "workspace": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
                     },
                     "repo": {
                       "type": "string",
@@ -10810,6 +11993,11 @@
                       "description": "",
                       "default": "",
                       "nullable": true
+                    },
+                    "workspace": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
                     },
                     "repo": {
                       "type": "string",
@@ -11301,6 +12489,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "github_installation_id",
+            "in": "query",
+            "required": false,
+            "description": "The ID of the GitHub installation. This will be used to get the GitHub installation settings. If not provided, the default GitHub installation settings will be used.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "security": [
@@ -11575,6 +12772,432 @@
               }
             },
             "description": "Metadata about the full scans and the dependency overview and dependency alert comment. Can be used in a pull request context."
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      }
+    },
+    "/orgs/{org_slug}/full-scans/{full_scan_id}/files/tar": {
+      "get": {
+        "tags": [
+          "Full Scans"
+        ],
+        "summary": "Download full scan files as tarball",
+        "operationId": "downloadOrgFullScanFilesAsTar",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "full_scan_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the full scan",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+              "full-scans:list"
+            ]
+          },
+          {
+            "basicAuth": [
+              "full-scans:list"
+            ]
+          }
+        ],
+        "description": "Download all files associated with a full scan in tar format.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- full-scans:list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/x-tar": {}
+            },
+            "description": "Tar archive of full scan files"
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      }
+    },
+    "/orgs/{org_slug}/full-scans/archive": {
+      "post": {
+        "tags": [
+          "Full Scans"
+        ],
+        "summary": "Create full scan from archive",
+        "operationId": "CreateOrgFullScanArchive",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repo",
+            "in": "query",
+            "required": true,
+            "description": "The slug of the repository to associate the full-scan with.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "description": "The workspace of the repository to associate the full-scan with.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "branch",
+            "in": "query",
+            "required": false,
+            "description": "The branch name to associate the full-scan with. Branch names must follow Git branch name rules: be 1–255 characters long; cannot be exactly @;  cannot begin or end with /, ., or .lock; cannot contain \"//\", \"..\", or \"@{\"; and cannot include control characters, spaces, or any of ~^:?*[.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "commit_message",
+            "in": "query",
+            "required": false,
+            "description": "The commit message to associate the full-scan with.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "commit_hash",
+            "in": "query",
+            "required": false,
+            "description": "The commit hash to associate the full-scan with.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pull_request",
+            "in": "query",
+            "required": false,
+            "description": "The pull request number to associate the full-scan with.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "committers",
+            "in": "query",
+            "required": false,
+            "description": "The committers to associate with the full-scan. Set query more than once to set multiple.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "integration_type",
+            "in": "query",
+            "required": false,
+            "description": "The integration type to associate the full-scan with. Defaults to \"Api\" if omitted.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "api",
+                "github",
+                "gitlab",
+                "bitbucket",
+                "azure"
+              ]
+            }
+          },
+          {
+            "name": "integration_org_slug",
+            "in": "query",
+            "required": false,
+            "description": "The integration org slug to associate the full-scan with. If omitted, the Socket org name will be used. This is used to generate links and badges.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "make_default_branch",
+            "in": "query",
+            "required": false,
+            "description": "Set the default branch of the repository to the branch of this full-scan. A branch name is required with this option.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "set_as_pending_head",
+            "in": "query",
+            "required": false,
+            "description": "Designate this full-scan as the latest scan of a given branch. Default branch head scans are included in org alerts. This is only supported on the default branch. A branch name is required with this option.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "tmp",
+            "in": "query",
+            "required": false,
+            "description": "Create a temporary full-scan that is not listed in the reports dashboard. Cannot be used when set_as_pending_head=true.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "scan_type",
+            "in": "query",
+            "required": false,
+            "description": "The type of scan to perform. Defaults to 'socket'. Must be 32 characters or less. Used for categorizing multiple SBOM heads per repository branch.",
+            "schema": {
+              "type": "string",
+              "default": "socket"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string",
+                  "default": {
+                    "type": "Buffer",
+                    "data": []
+                  },
+                  "format": "binary",
+                  "description": ""
+                },
+                "properties": {},
+                "description": ""
+              }
+            }
+          },
+          "required": false
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "full-scans:create"
+            ]
+          },
+          {
+            "basicAuth": [
+              "full-scans:create"
+            ]
+          }
+        ],
+        "description": "Create a full scan by uploading one or more archives. Supported archive formats include **.tar**, **.tar.gz/.tgz**, and **.zip**.\n\nEach uploaded archive is extracted server-side and any supported manifest files (like package.json, package-lock.json, pnpm-lock.yaml, etc.) are ingested for the scan. If you upload multiple archives in a single request, the manifests from every archive are merged into one full scan. The response includes any files that were ignored.\n\nThe maximum combined number of files extracted from your upload is 5000 and each extracted file can be no bigger than 67 MB.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- full-scans:create",
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "organization_id": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "organization_slug": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "repository_id": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "repository_slug": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "branch": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "commit_message": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "commit_hash": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "pull_request": {
+                      "type": "integer",
+                      "description": "",
+                      "default": 0,
+                      "nullable": true
+                    },
+                    "committers": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "description": ""
+                    },
+                    "html_url": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "api_url": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "workspace": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "repo": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "html_report_url": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "integration_type": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "integration_repo_url": {
+                      "type": "string",
+                      "description": "",
+                      "default": ""
+                    },
+                    "integration_branch_url": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "integration_commit_url": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "integration_pull_request_url": {
+                      "type": "string",
+                      "description": "",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "scan_state": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "precrawl",
+                        "resolve",
+                        "scan"
+                      ],
+                      "description": "The current processing status of the SBOM",
+                      "default": "pending",
+                      "nullable": true
+                    },
+                    "unmatchedFiles": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "",
+                        "default": ""
+                      },
+                      "description": ""
+                    }
+                  },
+                  "description": ""
+                }
+              }
+            },
+            "description": "The details of the created full scan."
           },
           "400": {
             "$ref": "#/components/responses/SocketBadRequest"
@@ -12633,6 +14256,15 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "github_installation_id",
+            "in": "query",
+            "required": false,
+            "description": "The ID of the GitHub installation. This will be used to get the GitHub installation settings. If not provided, the default GitHub installation settings will be used.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "security": [
@@ -13111,6 +14743,15 @@
             "schema": {
               "type": "boolean",
               "default": false
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "description": "The workspace of the repository.",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -14288,6 +15929,58 @@
                             "default": "",
                             "nullable": true
                           },
+                          "integration_meta": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "github"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "description": "",
+                                    "properties": {
+                                      "installation_id": {
+                                        "type": "string",
+                                        "description": "The GitHub installation_id of the active associated Socket GitHub App",
+                                        "default": ""
+                                      },
+                                      "installation_login": {
+                                        "type": "string",
+                                        "description": "The GitHub login name that the active Socket GitHub App installation is installed to",
+                                        "default": ""
+                                      },
+                                      "repo_name": {
+                                        "type": "string",
+                                        "description": "The name of the associated GitHub repo.",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "repo_id": {
+                                        "type": "string",
+                                        "description": "The id of the associated GitHub repo.",
+                                        "default": "",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "installation_id",
+                                      "installation_login",
+                                      "repo_id",
+                                      "repo_name"
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "nullable": true
+                          },
                           "name": {
                             "type": "string",
                             "description": "The name of the repository",
@@ -14324,6 +16017,11 @@
                             "description": "The default branch of the repository",
                             "default": "main",
                             "nullable": true
+                          },
+                          "workspace": {
+                            "type": "string",
+                            "description": "The workspace of the repository",
+                            "default": ""
                           }
                         },
                         "description": ""
@@ -14424,6 +16122,11 @@
                     "description": "The default branch of the repository",
                     "default": "main",
                     "nullable": true
+                  },
+                  "workspace": {
+                    "type": "string",
+                    "description": "The workspace of the repository",
+                    "default": ""
                   }
                 },
                 "description": ""
@@ -14479,6 +16182,58 @@
                       "default": "",
                       "nullable": true
                     },
+                    "integration_meta": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "github"
+                              ]
+                            },
+                            "value": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "description": "",
+                              "properties": {
+                                "installation_id": {
+                                  "type": "string",
+                                  "description": "The GitHub installation_id of the active associated Socket GitHub App",
+                                  "default": ""
+                                },
+                                "installation_login": {
+                                  "type": "string",
+                                  "description": "The GitHub login name that the active Socket GitHub App installation is installed to",
+                                  "default": ""
+                                },
+                                "repo_name": {
+                                  "type": "string",
+                                  "description": "The name of the associated GitHub repo.",
+                                  "default": "",
+                                  "nullable": true
+                                },
+                                "repo_id": {
+                                  "type": "string",
+                                  "description": "The id of the associated GitHub repo.",
+                                  "default": "",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "installation_id",
+                                "installation_login",
+                                "repo_id",
+                                "repo_name"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "nullable": true
+                    },
                     "name": {
                       "type": "string",
                       "description": "The name of the repository",
@@ -14515,6 +16270,11 @@
                       "description": "The default branch of the repository",
                       "default": "main",
                       "nullable": true
+                    },
+                    "workspace": {
+                      "type": "string",
+                      "description": "The workspace of the repository",
+                      "default": ""
                     }
                   },
                   "description": ""
@@ -14564,6 +16324,15 @@
             "in": "path",
             "required": true,
             "description": "The slug of the repository",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "description": "The workspace of the repository",
             "schema": {
               "type": "string"
             }
@@ -14617,6 +16386,58 @@
                       "default": "",
                       "nullable": true
                     },
+                    "integration_meta": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "github"
+                              ]
+                            },
+                            "value": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "description": "",
+                              "properties": {
+                                "installation_id": {
+                                  "type": "string",
+                                  "description": "The GitHub installation_id of the active associated Socket GitHub App",
+                                  "default": ""
+                                },
+                                "installation_login": {
+                                  "type": "string",
+                                  "description": "The GitHub login name that the active Socket GitHub App installation is installed to",
+                                  "default": ""
+                                },
+                                "repo_name": {
+                                  "type": "string",
+                                  "description": "The name of the associated GitHub repo.",
+                                  "default": "",
+                                  "nullable": true
+                                },
+                                "repo_id": {
+                                  "type": "string",
+                                  "description": "The id of the associated GitHub repo.",
+                                  "default": "",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "installation_id",
+                                "installation_login",
+                                "repo_id",
+                                "repo_name"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "nullable": true
+                    },
                     "name": {
                       "type": "string",
                       "description": "The name of the repository",
@@ -14654,6 +16475,11 @@
                       "default": "main",
                       "nullable": true
                     },
+                    "workspace": {
+                      "type": "string",
+                      "description": "The workspace of the repository",
+                      "default": ""
+                    },
                     "slig": {
                       "type": "string",
                       "description": "The slug of the repository. This typo is intentionally preserved for backwards compatibility reasons.",
@@ -14668,11 +16494,13 @@
                     "head_full_scan_id",
                     "homepage",
                     "id",
+                    "integration_meta",
                     "name",
                     "slig",
                     "slug",
                     "updated_at",
-                    "visibility"
+                    "visibility",
+                    "workspace"
                   ]
                 }
               }
@@ -14721,6 +16549,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "description": "The workspace of the repository",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -14766,6 +16603,11 @@
                     "description": "The default branch of the repository",
                     "default": "main",
                     "nullable": true
+                  },
+                  "workspace": {
+                    "type": "string",
+                    "description": "The workspace of the repository",
+                    "default": ""
                   }
                 },
                 "description": ""
@@ -14821,6 +16663,58 @@
                       "default": "",
                       "nullable": true
                     },
+                    "integration_meta": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "github"
+                              ]
+                            },
+                            "value": {
+                              "type": "object",
+                              "additionalProperties": false,
+                              "description": "",
+                              "properties": {
+                                "installation_id": {
+                                  "type": "string",
+                                  "description": "The GitHub installation_id of the active associated Socket GitHub App",
+                                  "default": ""
+                                },
+                                "installation_login": {
+                                  "type": "string",
+                                  "description": "The GitHub login name that the active Socket GitHub App installation is installed to",
+                                  "default": ""
+                                },
+                                "repo_name": {
+                                  "type": "string",
+                                  "description": "The name of the associated GitHub repo.",
+                                  "default": "",
+                                  "nullable": true
+                                },
+                                "repo_id": {
+                                  "type": "string",
+                                  "description": "The id of the associated GitHub repo.",
+                                  "default": "",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "installation_id",
+                                "installation_login",
+                                "repo_id",
+                                "repo_name"
+                              ]
+                            }
+                          }
+                        }
+                      ],
+                      "nullable": true
+                    },
                     "name": {
                       "type": "string",
                       "description": "The name of the repository",
@@ -14857,6 +16751,11 @@
                       "description": "The default branch of the repository",
                       "default": "main",
                       "nullable": true
+                    },
+                    "workspace": {
+                      "type": "string",
+                      "description": "The workspace of the repository",
+                      "default": ""
                     }
                   },
                   "description": ""
@@ -14904,6 +16803,15 @@
             "in": "path",
             "required": true,
             "description": "The slug of the repository",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "description": "The workspace of the repository",
             "schema": {
               "type": "string"
             }
@@ -16268,6 +18176,153 @@
                             "action"
                           ]
                         },
+                        "ghaArgToSink": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaArgToSink issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaEnvToSink": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaEnvToSink issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaContextToSink": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaContextToSink issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaArgToOutput": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaArgToOutput issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaArgToEnv": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaArgToEnv issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaContextToOutput": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaContextToOutput issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaContextToEnv": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaContextToEnv issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
                         "licenseSpdxDisj": {
                           "type": "object",
                           "additionalProperties": false,
@@ -17989,6 +20044,195 @@
                           "required": [
                             "action"
                           ]
+                        },
+                        "vsxProposedApiUsage": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxProposedApiUsage issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxActivationWildcard": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxActivationWildcard issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxWorkspaceContainsActivation": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxWorkspaceContainsActivation issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxUntrustedWorkspaceSupported": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxUntrustedWorkspaceSupported issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxVirtualWorkspaceSupported": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxVirtualWorkspaceSupported issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxWebviewContribution": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxWebviewContribution issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxDebuggerContribution": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxDebuggerContribution issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxExtensionDependency": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxExtensionDependency issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxExtensionPack": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxExtensionPack issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
                         }
                       },
                       "description": "",
@@ -18488,6 +20732,153 @@
                               "ignore"
                             ],
                             "description": "The action to take for generic issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaArgToSink": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaArgToSink issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaEnvToSink": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaEnvToSink issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaContextToSink": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaContextToSink issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaArgToOutput": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaArgToOutput issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaArgToEnv": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaArgToEnv issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaContextToOutput": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaContextToOutput issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaContextToEnv": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaContextToEnv issues."
                           }
                         },
                         "required": [
@@ -20210,6 +22601,195 @@
                               "ignore"
                             ],
                             "description": "The action to take for potentialVulnerability issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxProposedApiUsage": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxProposedApiUsage issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxActivationWildcard": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxActivationWildcard issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxWorkspaceContainsActivation": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxWorkspaceContainsActivation issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxUntrustedWorkspaceSupported": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxUntrustedWorkspaceSupported issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxVirtualWorkspaceSupported": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxVirtualWorkspaceSupported issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxWebviewContribution": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxWebviewContribution issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxDebuggerContribution": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxDebuggerContribution issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxExtensionDependency": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxExtensionDependency issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxExtensionPack": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxExtensionPack issues."
                           }
                         },
                         "required": [
@@ -21033,6 +23613,153 @@
                             "action"
                           ]
                         },
+                        "ghaArgToSink": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaArgToSink issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaEnvToSink": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaEnvToSink issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaContextToSink": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaContextToSink issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaArgToOutput": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaArgToOutput issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaArgToEnv": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaArgToEnv issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaContextToOutput": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaContextToOutput issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaContextToEnv": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaContextToEnv issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
                         "licenseSpdxDisj": {
                           "type": "object",
                           "additionalProperties": false,
@@ -22754,6 +25481,195 @@
                           "required": [
                             "action"
                           ]
+                        },
+                        "vsxProposedApiUsage": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxProposedApiUsage issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxActivationWildcard": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxActivationWildcard issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxWorkspaceContainsActivation": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxWorkspaceContainsActivation issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxUntrustedWorkspaceSupported": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxUntrustedWorkspaceSupported issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxVirtualWorkspaceSupported": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxVirtualWorkspaceSupported issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxWebviewContribution": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxWebviewContribution issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxDebuggerContribution": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxDebuggerContribution issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxExtensionDependency": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxExtensionDependency issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxExtensionPack": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxExtensionPack issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
                         }
                       },
                       "description": ""
@@ -23256,6 +26172,153 @@
                               "ignore"
                             ],
                             "description": "The action to take for generic issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaArgToSink": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaArgToSink issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaEnvToSink": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaEnvToSink issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaContextToSink": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaContextToSink issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaArgToOutput": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaArgToOutput issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaArgToEnv": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaArgToEnv issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaContextToOutput": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaContextToOutput issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "ghaContextToEnv": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for ghaContextToEnv issues."
                           }
                         },
                         "required": [
@@ -24983,6 +28046,195 @@
                         "required": [
                           "action"
                         ]
+                      },
+                      "vsxProposedApiUsage": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxProposedApiUsage issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxActivationWildcard": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxActivationWildcard issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxWorkspaceContainsActivation": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxWorkspaceContainsActivation issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxUntrustedWorkspaceSupported": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxUntrustedWorkspaceSupported issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxVirtualWorkspaceSupported": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxVirtualWorkspaceSupported issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxWebviewContribution": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxWebviewContribution issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxDebuggerContribution": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxDebuggerContribution issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxExtensionDependency": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxExtensionDependency issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
+                      },
+                      "vsxExtensionPack": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": [
+                              "defer",
+                              "error",
+                              "warn",
+                              "monitor",
+                              "ignore"
+                            ],
+                            "description": "The action to take for vsxExtensionPack issues."
+                          }
+                        },
+                        "required": [
+                          "action"
+                        ]
                       }
                     },
                     "description": ""
@@ -25438,6 +28690,153 @@
                                 "ignore"
                               ],
                               "description": "The action to take for generic issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaArgToSink": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaArgToSink issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaEnvToSink": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaEnvToSink issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaContextToSink": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaContextToSink issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaArgToOutput": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaArgToOutput issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaArgToEnv": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaArgToEnv issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaContextToOutput": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaContextToOutput issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "ghaContextToEnv": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for ghaContextToEnv issues."
                             }
                           },
                           "required": [
@@ -27165,6 +30564,195 @@
                           "required": [
                             "action"
                           ]
+                        },
+                        "vsxProposedApiUsage": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxProposedApiUsage issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxActivationWildcard": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxActivationWildcard issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxWorkspaceContainsActivation": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxWorkspaceContainsActivation issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxUntrustedWorkspaceSupported": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxUntrustedWorkspaceSupported issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxVirtualWorkspaceSupported": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxVirtualWorkspaceSupported issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxWebviewContribution": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxWebviewContribution issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxDebuggerContribution": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxDebuggerContribution issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxExtensionDependency": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxExtensionDependency issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
+                        },
+                        "vsxExtensionPack": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "",
+                          "properties": {
+                            "action": {
+                              "type": "string",
+                              "enum": [
+                                "defer",
+                                "error",
+                                "warn",
+                                "monitor",
+                                "ignore"
+                              ],
+                              "description": "The action to take for vsxExtensionPack issues."
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ]
                         }
                       },
                       "description": ""
@@ -27383,7 +30971,7 @@
             ]
           }
         ],
-        "description": "Returns an organization's license policy\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- license-policy:read",
+        "description": "Returns an organization's license policy including allow, warn, monitor, and deny categories.\nThe deny category contains all licenses that are not explicitly categorized as allow, warn, or monitor.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- license-policy:read",
         "responses": {
           "200": {
             "content": {
@@ -27456,51 +31044,440 @@
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
+                    "consoleTabularEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enable tabular console output"
+                    },
+                    "consoleJsonEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enable JSON console output"
+                    },
+                    "verbose": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enable verbose logging"
+                    },
+                    "allLanguagesEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enable all language SAST scanning"
+                    },
                     "pythonSastEnabled": {
                       "type": "boolean",
                       "default": false,
-                      "description": "Run a SAST Scan on your source code as part of the Socket Basics scan"
-                    },
-                    "golangSastEnabled": {
-                      "type": "boolean",
-                      "default": false,
-                      "description": "Run a SAST Scan on your source code as part of the Socket Basics scan"
+                      "description": "Run Python SAST scanning"
                     },
                     "javascriptSastEnabled": {
                       "type": "boolean",
                       "default": false,
-                      "description": "Run a SAST Scan on your source code as part of the Socket Basics scan"
+                      "description": "Run JavaScript SAST scanning"
+                    },
+                    "goSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run Go SAST scanning"
+                    },
+                    "golangSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run Golang SAST scanning"
+                    },
+                    "javaSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run Java SAST scanning"
+                    },
+                    "phpSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run PHP SAST scanning"
+                    },
+                    "rubySastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run Ruby SAST scanning"
+                    },
+                    "csharpSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run C# SAST scanning"
+                    },
+                    "dotnetSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run .NET SAST scanning"
+                    },
+                    "cSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run C SAST scanning"
+                    },
+                    "cppSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run C++ SAST scanning"
+                    },
+                    "kotlinSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run Kotlin SAST scanning"
+                    },
+                    "scalaSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run Scala SAST scanning"
+                    },
+                    "swiftSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run Swift SAST scanning"
+                    },
+                    "rustSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run Rust SAST scanning"
+                    },
+                    "elixirSastEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Run Elixir SAST scanning"
+                    },
+                    "allRulesEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enable all SAST rules"
+                    },
+                    "pythonEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled Python SAST rules",
+                      "default": ""
+                    },
+                    "pythonDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Python SAST rules",
+                      "default": ""
+                    },
+                    "javascriptEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled JavaScript SAST rules",
+                      "default": ""
+                    },
+                    "javascriptDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled JavaScript SAST rules",
+                      "default": ""
+                    },
+                    "goEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled Go SAST rules",
+                      "default": ""
+                    },
+                    "goDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Go SAST rules",
+                      "default": ""
+                    },
+                    "javaEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled Java SAST rules",
+                      "default": ""
+                    },
+                    "javaDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Java SAST rules",
+                      "default": ""
+                    },
+                    "kotlinEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled Kotlin SAST rules",
+                      "default": ""
+                    },
+                    "kotlinDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Kotlin SAST rules",
+                      "default": ""
+                    },
+                    "scalaEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled Scala SAST rules",
+                      "default": ""
+                    },
+                    "scalaDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Scala SAST rules",
+                      "default": ""
+                    },
+                    "phpEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled PHP SAST rules",
+                      "default": ""
+                    },
+                    "phpDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled PHP SAST rules",
+                      "default": ""
+                    },
+                    "rubyEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled Ruby SAST rules",
+                      "default": ""
+                    },
+                    "rubyDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Ruby SAST rules",
+                      "default": ""
+                    },
+                    "csharpEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled C# SAST rules",
+                      "default": ""
+                    },
+                    "csharpDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled C# SAST rules",
+                      "default": ""
+                    },
+                    "dotnetEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled .NET SAST rules",
+                      "default": ""
+                    },
+                    "dotnetDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled .NET SAST rules",
+                      "default": ""
+                    },
+                    "cEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled C SAST rules",
+                      "default": ""
+                    },
+                    "cDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled C SAST rules",
+                      "default": ""
+                    },
+                    "cppEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled C++ SAST rules",
+                      "default": ""
+                    },
+                    "cppDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled C++ SAST rules",
+                      "default": ""
+                    },
+                    "swiftEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled Swift SAST rules",
+                      "default": ""
+                    },
+                    "swiftDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Swift SAST rules",
+                      "default": ""
+                    },
+                    "rustEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled Rust SAST rules",
+                      "default": ""
+                    },
+                    "rustDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Rust SAST rules",
+                      "default": ""
+                    },
+                    "elixirEnabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of enabled Elixir SAST rules",
+                      "default": ""
+                    },
+                    "elixirDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Elixir SAST rules",
+                      "default": ""
+                    },
+                    "openGrepNotificationMethod": {
+                      "type": "string",
+                      "description": "Notification method for OpenGrep",
+                      "default": ""
+                    },
+                    "socketTier1Enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enable Socket Tier 1 reachability analysis"
+                    },
+                    "socketAdditionalParams": {
+                      "type": "string",
+                      "description": "Additional parameters for Socket SCA",
+                      "default": ""
                     },
                     "secretScanningEnabled": {
                       "type": "boolean",
                       "default": false,
-                      "description": "Scan for hardcoded secrets and credentials in your code as part of the Socket Basics scan"
+                      "description": "Enable secret scanning"
+                    },
+                    "trufflehogExcludeDir": {
+                      "type": "string",
+                      "description": "Directories to exclude from Trufflehog scanning",
+                      "default": ""
+                    },
+                    "trufflehogShowUnverified": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Show unverified secrets in Trufflehog results"
+                    },
+                    "trufflehogNotificationMethod": {
+                      "type": "string",
+                      "description": "Notification method for Trufflehog",
+                      "default": ""
+                    },
+                    "containerImagesToScan": {
+                      "type": "string",
+                      "description": "Comma-separated list of container images to scan",
+                      "default": ""
+                    },
+                    "dockerfiles": {
+                      "type": "string",
+                      "description": "Comma-separated list of Dockerfiles to scan",
+                      "default": ""
                     },
                     "trivyImageEnabled": {
                       "type": "boolean",
                       "default": false,
-                      "description": "Run a vulnerability scan on your Docker images as part of the Socket Basics scan"
+                      "description": "Enable Trivy image scanning"
                     },
                     "trivyDockerfileEnabled": {
                       "type": "boolean",
                       "default": false,
-                      "description": "Run a vulnerability scan on your Dockerfiles as part of the Socket Basics scan"
+                      "description": "Enable Trivy Dockerfile scanning"
+                    },
+                    "trivyNotificationMethod": {
+                      "type": "string",
+                      "description": "Notification method for Trivy",
+                      "default": ""
+                    },
+                    "trivyDisabledRules": {
+                      "type": "string",
+                      "description": "Comma-separated list of disabled Trivy rules",
+                      "default": ""
+                    },
+                    "trivyImageScanningDisabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Disable Trivy image scanning"
+                    },
+                    "slackWebhookUrl": {
+                      "type": "string",
+                      "description": "Slack webhook URL for notifications",
+                      "default": ""
+                    },
+                    "webhookUrl": {
+                      "type": "string",
+                      "description": "Generic webhook URL for notifications",
+                      "default": ""
+                    },
+                    "msSentinelWorkspaceId": {
+                      "type": "string",
+                      "description": "Microsoft Sentinel workspace ID",
+                      "default": ""
+                    },
+                    "msSentinelKey": {
+                      "type": "string",
+                      "description": "Microsoft Sentinel key",
+                      "default": ""
+                    },
+                    "sumologicEndpoint": {
+                      "type": "string",
+                      "description": "Sumo Logic endpoint URL",
+                      "default": ""
+                    },
+                    "jiraUrl": {
+                      "type": "string",
+                      "description": "Jira server URL",
+                      "default": ""
+                    },
+                    "jiraProject": {
+                      "type": "string",
+                      "description": "Jira project key",
+                      "default": ""
+                    },
+                    "jiraEmail": {
+                      "type": "string",
+                      "description": "Jira user email",
+                      "default": ""
+                    },
+                    "jiraApiToken": {
+                      "type": "string",
+                      "description": "Jira API token",
+                      "default": ""
+                    },
+                    "githubToken": {
+                      "type": "string",
+                      "description": "GitHub API token",
+                      "default": ""
+                    },
+                    "githubApiUrl": {
+                      "type": "string",
+                      "description": "GitHub API URL",
+                      "default": ""
+                    },
+                    "msteamsWebhookUrl": {
+                      "type": "string",
+                      "description": "Microsoft Teams webhook URL",
+                      "default": ""
+                    },
+                    "s3Enabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enable S3 upload for scan results"
+                    },
+                    "s3Bucket": {
+                      "type": "string",
+                      "description": "S3 bucket name",
+                      "default": ""
+                    },
+                    "s3AccessKey": {
+                      "type": "string",
+                      "description": "S3 access key",
+                      "default": ""
+                    },
+                    "s3SecretKey": {
+                      "type": "string",
+                      "description": "S3 secret key",
+                      "default": ""
+                    },
+                    "s3Endpoint": {
+                      "type": "string",
+                      "description": "S3 endpoint URL",
+                      "default": ""
+                    },
+                    "s3Region": {
+                      "type": "string",
+                      "description": "S3 region",
+                      "default": ""
+                    },
+                    "externalCveScanningEnabled": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Enable external CVE scanning"
                     },
                     "socketScanningEnabled": {
                       "type": "boolean",
                       "default": false,
-                      "description": "Scan dependencies for security vulnerabilities and issues as part of the Socket Basics scan"
+                      "description": "Enable Socket dependency scanning (legacy)"
                     },
                     "socketScaEnabled": {
                       "type": "boolean",
                       "default": false,
-                      "description": "Enables or disable running a Socket SCA Scan as part of the Socket Basics scan. If you have Socket already enabled via the Github App this is not needed. Socket SCA provides 0 day protection of Open Source Supply Chain packages, CVE Reachability, and operational risk of packages."
+                      "description": "Enable Socket SCA scanning (legacy)"
                     },
                     "additionalParameters": {
                       "type": "string",
-                      "description": "",
-                      "default": "",
-                      "format": "Additional configuration for Socket Basics, includes support for experimental and custom tooling."
+                      "description": "Additional configuration parameters (legacy)",
+                      "default": ""
                     }
                   },
                   "description": ""
@@ -27615,10 +31592,28 @@
             }
           },
           {
+            "name": "filters.repoFullName",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of repo full names that should be included",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filters.repoFullName.notIn",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of repo full names that should be excluded",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "filters.repoLabels",
             "in": "query",
             "required": false,
-            "description": "Comma-separated list of repo labels that should be included",
+            "description": "Comma-separated list of repo labels that should be included. Use \"\" to filter for repositories with no labels.",
             "schema": {
               "type": "string"
             }
@@ -27627,7 +31622,7 @@
             "name": "filters.repoLabels.notIn",
             "in": "query",
             "required": false,
-            "description": "Comma-separated list of repo labels that should be excluded",
+            "description": "Comma-separated list of repo labels that should be excluded. Use \"\" to filter for repositories with no labels.",
             "schema": {
               "type": "string"
             }
@@ -27708,7 +31703,7 @@
             "name": "filters.alertActionSourceType",
             "in": "query",
             "required": false,
-            "description": "Comma-separated list of alert action source types (\"fallback\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be included",
+            "description": "Comma-separated list of alert action source types (\"fallback\", \"injected-alert\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be included",
             "schema": {
               "type": "string"
             }
@@ -27717,7 +31712,7 @@
             "name": "filters.alertActionSourceType.notIn",
             "in": "query",
             "required": false,
-            "description": "Comma-separated list of alert action source types (\"fallback\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be excluded",
+            "description": "Comma-separated list of alert action source types (\"fallback\", \"injected-alert\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be excluded",
             "schema": {
               "type": "string"
             }
@@ -27849,10 +31844,28 @@
             }
           },
           {
+            "name": "filters.alertReachabilityAnalysisType",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of alert CVE reachability analysis types (\"full-scan\" or \"precomputed\") that should be included",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filters.alertReachabilityAnalysisType.notIn",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of alert CVE reachability analysis types (\"full-scan\" or \"precomputed\") that should be excluded",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "filters.alertPriority",
             "in": "query",
             "required": false,
-            "description": "Alert priority (\"low\", \"medium\", or \"high\")",
+            "description": "Alert priority (\"low\", \"medium\", \"high\", or \"critical\")",
             "schema": {
               "type": "string"
             }
@@ -27861,7 +31874,45 @@
             "name": "filters.alertPriority.notIn",
             "in": "query",
             "required": false,
-            "description": "Alert priority (\"low\", \"medium\", or \"high\")",
+            "description": "Alert priority (\"low\", \"medium\", \"high\", or \"critical\")",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filters.alertKEV",
+            "in": "query",
+            "required": false,
+            "description": "Alert KEV (Known Exploited Vulnerability) filter flag",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "filters.alertKEV.notIn",
+            "in": "query",
+            "required": false,
+            "description": "Alert KEV (Known Exploited Vulnerability) filter flag",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "filters.alertEPSS",
+            "in": "query",
+            "required": false,
+            "description": "Alert EPSS (\"low\", \"medium\", \"high\", \"critical\")",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filters.alertEPSS.notIn",
+            "in": "query",
+            "required": false,
+            "description": "Alert EPSS (\"low\", \"medium\", \"high\", \"critical\")",
             "schema": {
               "type": "string"
             }
@@ -27962,6 +32013,11 @@
                         "additionalProperties": false,
                         "description": "",
                         "properties": {
+                          "repoFullName": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
                           "repoId": {
                             "type": "string",
                             "description": "",
@@ -28237,6 +32293,7 @@
                           "defaultBranch",
                           "dependency",
                           "fullScanId",
+                          "repoFullName",
                           "repoId",
                           "repoLabelIds",
                           "repoLabels",
@@ -28298,6 +32355,15 @@
                               },
                               "description": "Comma-separated list of repo slugs that should be excluded"
                             },
+                            "repoFullName": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "description": "",
+                                "default": ""
+                              },
+                              "description": "Comma-separated list of repo full names that should be excluded"
+                            },
                             "repoLabels": {
                               "type": "array",
                               "items": {
@@ -28305,7 +32371,7 @@
                                 "description": "",
                                 "default": ""
                               },
-                              "description": "Comma-separated list of repo labels that should be excluded"
+                              "description": "Comma-separated list of repo labels that should be excluded. Use \"\" to filter for repositories with no labels."
                             },
                             "alertType": {
                               "type": "array",
@@ -28350,7 +32416,7 @@
                                 "description": "",
                                 "default": ""
                               },
-                              "description": "Comma-separated list of alert action source types (\"fallback\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be excluded"
+                              "description": "Comma-separated list of alert action source types (\"fallback\", \"injected-alert\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be excluded"
                             },
                             "alertFixType": {
                               "type": "array",
@@ -28415,6 +32481,15 @@
                               },
                               "description": "Comma-separated list of alert CVE reachability types (\"direct_dependency\", \"error\", \"maybe_reachable\", \"missing_support\", \"pending\", \"reachable\", \"undeterminable_reachability\", \"unknown\", or \"unreachable\") that should be excluded"
                             },
+                            "alertReachabilityAnalysisType": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "description": "",
+                                "default": ""
+                              },
+                              "description": "Comma-separated list of alert CVE reachability analysis types (\"full-scan\" or \"precomputed\") that should be excluded"
+                            },
                             "alertPriority": {
                               "type": "array",
                               "items": {
@@ -28422,7 +32497,25 @@
                                 "description": "",
                                 "default": ""
                               },
-                              "description": "Alert priority (\"low\", \"medium\", or \"high\")"
+                              "description": "Alert priority (\"low\", \"medium\", \"high\", or \"critical\")"
+                            },
+                            "alertKEV": {
+                              "type": "array",
+                              "items": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": ""
+                              },
+                              "description": "Alert KEV (Known Exploited Vulnerability) filter flag"
+                            },
+                            "alertEPSS": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "description": "",
+                                "default": ""
+                              },
+                              "description": "Alert EPSS (\"low\", \"medium\", \"high\", \"critical\")"
                             },
                             "dependencyDirect": {
                               "type": "array",
@@ -28532,7 +32625,7 @@
             "name": "aggregation.fields",
             "in": "query",
             "required": false,
-            "description": "Comma-separated list of fields that should be used for count aggregation (allowed: alertSeverity,repoSlug,repoLabels,alertType,artifactType,alertAction,alertActionSourceType,alertFixType,alertCategory,alertCveId,alertCveTitle,alertCweId,alertCweName,alertReachabilityType,alertPriority,dependencyDirect,dependencyDev,dependencyDead)",
+            "description": "Comma-separated list of fields that should be used for count aggregation (allowed: alertSeverity,repoSlug,repoFullName,repoLabels,alertType,artifactType,alertAction,alertActionSourceType,alertFixType,alertCategory,alertCveId,alertCveTitle,alertCweId,alertCweName,alertReachabilityType,alertReachabilityAnalysisType,alertPriority,alertKEV,alertEPSS,dependencyDirect,dependencyDev,dependencyDead)",
             "schema": {
               "type": "string",
               "default": ""
@@ -28575,10 +32668,28 @@
             }
           },
           {
+            "name": "filters.repoFullName",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of repo full names that should be included",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filters.repoFullName.notIn",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of repo full names that should be excluded",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "filters.repoLabels",
             "in": "query",
             "required": false,
-            "description": "Comma-separated list of repo labels that should be included",
+            "description": "Comma-separated list of repo labels that should be included. Use \"\" to filter for repositories with no labels.",
             "schema": {
               "type": "string"
             }
@@ -28587,7 +32698,7 @@
             "name": "filters.repoLabels.notIn",
             "in": "query",
             "required": false,
-            "description": "Comma-separated list of repo labels that should be excluded",
+            "description": "Comma-separated list of repo labels that should be excluded. Use \"\" to filter for repositories with no labels.",
             "schema": {
               "type": "string"
             }
@@ -28668,7 +32779,7 @@
             "name": "filters.alertActionSourceType",
             "in": "query",
             "required": false,
-            "description": "Comma-separated list of alert action source types (\"fallback\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be included",
+            "description": "Comma-separated list of alert action source types (\"fallback\", \"injected-alert\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be included",
             "schema": {
               "type": "string"
             }
@@ -28677,7 +32788,7 @@
             "name": "filters.alertActionSourceType.notIn",
             "in": "query",
             "required": false,
-            "description": "Comma-separated list of alert action source types (\"fallback\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be excluded",
+            "description": "Comma-separated list of alert action source types (\"fallback\", \"injected-alert\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be excluded",
             "schema": {
               "type": "string"
             }
@@ -28809,10 +32920,28 @@
             }
           },
           {
+            "name": "filters.alertReachabilityAnalysisType",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of alert CVE reachability analysis types (\"full-scan\" or \"precomputed\") that should be included",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filters.alertReachabilityAnalysisType.notIn",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of alert CVE reachability analysis types (\"full-scan\" or \"precomputed\") that should be excluded",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "filters.alertPriority",
             "in": "query",
             "required": false,
-            "description": "Alert priority (\"low\", \"medium\", or \"high\")",
+            "description": "Alert priority (\"low\", \"medium\", \"high\", or \"critical\")",
             "schema": {
               "type": "string"
             }
@@ -28821,7 +32950,45 @@
             "name": "filters.alertPriority.notIn",
             "in": "query",
             "required": false,
-            "description": "Alert priority (\"low\", \"medium\", or \"high\")",
+            "description": "Alert priority (\"low\", \"medium\", \"high\", or \"critical\")",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filters.alertKEV",
+            "in": "query",
+            "required": false,
+            "description": "Alert KEV (Known Exploited Vulnerability) filter flag",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "filters.alertKEV.notIn",
+            "in": "query",
+            "required": false,
+            "description": "Alert KEV (Known Exploited Vulnerability) filter flag",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "filters.alertEPSS",
+            "in": "query",
+            "required": false,
+            "description": "Alert EPSS (\"low\", \"medium\", \"high\", \"critical\")",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filters.alertEPSS.notIn",
+            "in": "query",
+            "required": false,
+            "description": "Alert EPSS (\"low\", \"medium\", \"high\", \"critical\")",
             "schema": {
               "type": "string"
             }
@@ -28989,6 +33156,15 @@
                               },
                               "description": "Comma-separated list of repo slugs that should be excluded"
                             },
+                            "repoFullName": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "description": "",
+                                "default": ""
+                              },
+                              "description": "Comma-separated list of repo full names that should be excluded"
+                            },
                             "repoLabels": {
                               "type": "array",
                               "items": {
@@ -28996,7 +33172,7 @@
                                 "description": "",
                                 "default": ""
                               },
-                              "description": "Comma-separated list of repo labels that should be excluded"
+                              "description": "Comma-separated list of repo labels that should be excluded. Use \"\" to filter for repositories with no labels."
                             },
                             "alertType": {
                               "type": "array",
@@ -29041,7 +33217,7 @@
                                 "description": "",
                                 "default": ""
                               },
-                              "description": "Comma-separated list of alert action source types (\"fallback\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be excluded"
+                              "description": "Comma-separated list of alert action source types (\"fallback\", \"injected-alert\", \"org-policy\", \"reachability\", \"repo-label-policy\", \"socket-yml\", or \"triage\") that should be excluded"
                             },
                             "alertFixType": {
                               "type": "array",
@@ -29106,6 +33282,15 @@
                               },
                               "description": "Comma-separated list of alert CVE reachability types (\"direct_dependency\", \"error\", \"maybe_reachable\", \"missing_support\", \"pending\", \"reachable\", \"undeterminable_reachability\", \"unknown\", or \"unreachable\") that should be excluded"
                             },
+                            "alertReachabilityAnalysisType": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "description": "",
+                                "default": ""
+                              },
+                              "description": "Comma-separated list of alert CVE reachability analysis types (\"full-scan\" or \"precomputed\") that should be excluded"
+                            },
                             "alertPriority": {
                               "type": "array",
                               "items": {
@@ -29113,7 +33298,25 @@
                                 "description": "",
                                 "default": ""
                               },
-                              "description": "Alert priority (\"low\", \"medium\", or \"high\")"
+                              "description": "Alert priority (\"low\", \"medium\", \"high\", or \"critical\")"
+                            },
+                            "alertKEV": {
+                              "type": "array",
+                              "items": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": ""
+                              },
+                              "description": "Alert KEV (Known Exploited Vulnerability) filter flag"
+                            },
+                            "alertEPSS": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "description": "",
+                                "default": ""
+                              },
+                              "description": "Alert EPSS (\"low\", \"medium\", \"high\", \"critical\")"
                             },
                             "dependencyDirect": {
                               "type": "array",
@@ -29280,6 +33483,15 @@
             }
           },
           {
+            "name": "repoFullName",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of repo full names that should be included",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "repoSlug",
             "in": "query",
             "required": false,
@@ -29421,6 +33633,15 @@
                           "type": "object",
                           "additionalProperties": false,
                           "properties": {
+                            "repoFullName": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "description": "",
+                                "default": ""
+                              },
+                              "description": "Comma-separated list of repo full names that should be included"
+                            },
                             "repoSlug": {
                               "type": "array",
                               "items": {
@@ -30221,12 +34442,19 @@
                 "ChangePlanSubscriptionSeats",
                 "CreateApiToken",
                 "CreateLabel",
+                "CreateWebhook",
+                "DeleteFullScan",
                 "DeleteLabel",
                 "DeleteLabelSetting",
                 "DeleteReport",
                 "DeleteRepository",
+                "DeleteWebhook",
                 "DisassociateLabel",
+                "DowngradeOrganizationPlan",
                 "JoinOrganization",
+                "MemberAdded",
+                "MemberRemoved",
+                "MemberRoleChanged",
                 "RemoveLicenseOverlay",
                 "RemoveMember",
                 "ResetInvitationLink",
@@ -30246,7 +34474,9 @@
                 "UpdateAutopatchCurated",
                 "UpdateLabel",
                 "UpdateLabelSetting",
+                "UpdateLicenseOverlay",
                 "UpdateOrganizationSetting",
+                "UpdateWebhook",
                 "UpgradeOrganizationPlan"
               ]
             }
@@ -30455,7 +34685,7 @@
                 "properties": {
                   "max_quota": {
                     "type": "integer",
-                    "description": "",
+                    "description": "Maximum number of API calls allowed per month",
                     "default": 1000
                   },
                   "scopes": {
@@ -30477,6 +34707,8 @@
                         "dependencies",
                         "dependencies:list",
                         "dependencies:trend",
+                        "fixes",
+                        "fixes:list",
                         "full-scans",
                         "full-scans:list",
                         "full-scans:create",
@@ -30523,16 +34755,23 @@
                         "security-policy:read",
                         "socket-basics",
                         "socket-basics:read",
+                        "telemetry-policy",
+                        "telemetry-policy:update",
                         "threat-feed",
                         "threat-feed:list",
                         "triage",
                         "triage:alerts-list",
-                        "triage:alerts-update"
+                        "triage:alerts-update",
+                        "webhooks",
+                        "webhooks:create",
+                        "webhooks:list",
+                        "webhooks:update",
+                        "webhooks:delete"
                       ],
-                      "description": "",
+                      "description": "The scope of permissions for this API Token",
                       "default": "repo:list"
                     },
-                    "description": ""
+                    "description": "List of scopes granted to the API Token"
                   },
                   "visibility": {
                     "type": "string",
@@ -30549,7 +34788,7 @@
                     "properties": {
                       "email": {
                         "type": "string",
-                        "description": "",
+                        "description": "Email address of the committer",
                         "default": ""
                       },
                       "provider": {
@@ -30561,26 +34800,55 @@
                           "github",
                           "gitlab"
                         ],
-                        "description": "",
+                        "description": "The source control provider for the committer",
                         "default": "api"
                       },
                       "providerLoginName": {
                         "type": "string",
-                        "description": "",
+                        "description": "Login name on the provider platform",
                         "default": ""
                       },
                       "providerUserId": {
                         "type": "string",
-                        "description": "",
+                        "description": "User ID on the provider platform",
                         "default": ""
                       }
                     },
-                    "description": ""
+                    "description": "Committer information to associate with the API Token"
                   },
                   "name": {
                     "type": "string",
                     "description": "Name for the API Token",
                     "default": "api token"
+                  },
+                  "resources": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "organizationSlug": {
+                          "type": "string",
+                          "description": "Slug of the organization to grant access to",
+                          "default": ""
+                        },
+                        "repositorySlug": {
+                          "type": "string",
+                          "description": "Slug of the repository to grant access to",
+                          "default": ""
+                        },
+                        "workspace": {
+                          "type": "string",
+                          "description": "Workspace slug containing the specified repo",
+                          "default": ""
+                        }
+                      },
+                      "required": [
+                        "organizationSlug",
+                        "repositorySlug"
+                      ]
+                    },
+                    "description": "List of resources this API Token can access. Tokens with resource grants can only access a subset of routes that support this feature."
                   }
                 },
                 "required": [
@@ -30737,7 +35005,7 @@
                       "items": {
                         "type": "object",
                         "additionalProperties": false,
-                        "description": "",
+                        "description": "API Token response schema",
                         "properties": {
                           "committers": {
                             "type": "array",
@@ -30747,7 +35015,7 @@
                               "properties": {
                                 "email": {
                                   "type": "string",
-                                  "description": "",
+                                  "description": "Email address of the committer",
                                   "default": ""
                                 },
                                 "provider": {
@@ -30759,27 +35027,27 @@
                                     "github",
                                     "gitlab"
                                   ],
-                                  "description": "",
+                                  "description": "The source control provider for the committer",
                                   "default": "api"
                                 },
                                 "providerLoginName": {
                                   "type": "string",
-                                  "description": "",
+                                  "description": "Login name on the provider platform",
                                   "default": ""
                                 },
                                 "providerUserId": {
                                   "type": "string",
-                                  "description": "",
+                                  "description": "User ID on the provider platform",
                                   "default": ""
                                 }
                               },
-                              "description": ""
+                              "description": "Committer information associated with the API Token"
                             },
-                            "description": ""
+                            "description": "List of committers associated with this API Token"
                           },
                           "created_at": {
                             "type": "string",
-                            "description": "",
+                            "description": "Timestamp when the API Token was created",
                             "default": "",
                             "format": "date"
                           },
@@ -30790,13 +35058,13 @@
                           },
                           "last_used_at": {
                             "type": "string",
-                            "description": "",
+                            "description": "Timestamp when the API Token was last used",
                             "default": "",
                             "format": "date"
                           },
                           "max_quota": {
                             "type": "integer",
-                            "description": "",
+                            "description": "Maximum number of API calls allowed per month",
                             "default": 1000
                           },
                           "name": {
@@ -30824,6 +35092,8 @@
                                 "dependencies",
                                 "dependencies:list",
                                 "dependencies:trend",
+                                "fixes",
+                                "fixes:list",
                                 "full-scans",
                                 "full-scans:list",
                                 "full-scans:create",
@@ -30870,16 +35140,23 @@
                                 "security-policy:read",
                                 "socket-basics",
                                 "socket-basics:read",
+                                "telemetry-policy",
+                                "telemetry-policy:update",
                                 "threat-feed",
                                 "threat-feed:list",
                                 "triage",
                                 "triage:alerts-list",
-                                "triage:alerts-update"
+                                "triage:alerts-update",
+                                "webhooks",
+                                "webhooks:create",
+                                "webhooks:list",
+                                "webhooks:update",
+                                "webhooks:delete"
                               ],
-                              "description": "",
+                              "description": "The scope of permissions for this API Token",
                               "default": "repo:list"
                             },
-                            "description": ""
+                            "description": "List of scopes granted to the API Token"
                           },
                           "token": {
                             "type": "string",
@@ -30966,7 +35243,7 @@
                 "properties": {
                   "max_quota": {
                     "type": "integer",
-                    "description": "",
+                    "description": "Maximum number of API calls allowed per hour",
                     "default": 1000
                   },
                   "scopes": {
@@ -30988,6 +35265,8 @@
                         "dependencies",
                         "dependencies:list",
                         "dependencies:trend",
+                        "fixes",
+                        "fixes:list",
                         "full-scans",
                         "full-scans:list",
                         "full-scans:create",
@@ -31034,20 +35313,27 @@
                         "security-policy:read",
                         "socket-basics",
                         "socket-basics:read",
+                        "telemetry-policy",
+                        "telemetry-policy:update",
                         "threat-feed",
                         "threat-feed:list",
                         "triage",
                         "triage:alerts-list",
-                        "triage:alerts-update"
+                        "triage:alerts-update",
+                        "webhooks",
+                        "webhooks:create",
+                        "webhooks:list",
+                        "webhooks:update",
+                        "webhooks:delete"
                       ],
-                      "description": "",
+                      "description": "The scope of permissions for this API Token",
                       "default": "repo:list"
                     },
-                    "description": ""
+                    "description": "List of scopes granted to the API Token"
                   },
                   "token": {
                     "type": "string",
-                    "description": "",
+                    "description": "The API token to update",
                     "default": ""
                   },
                   "visibility": {
@@ -31065,7 +35351,7 @@
                     "properties": {
                       "email": {
                         "type": "string",
-                        "description": "",
+                        "description": "Email address of the committer",
                         "default": ""
                       },
                       "provider": {
@@ -31077,21 +35363,21 @@
                           "github",
                           "gitlab"
                         ],
-                        "description": "",
+                        "description": "The source control provider for the committer",
                         "default": "api"
                       },
                       "providerLoginName": {
                         "type": "string",
-                        "description": "",
+                        "description": "Login name on the provider platform",
                         "default": ""
                       },
                       "providerUserId": {
                         "type": "string",
-                        "description": "",
+                        "description": "User ID on the provider platform",
                         "default": ""
                       }
                     },
-                    "description": ""
+                    "description": "Committer information to associate with the API Token"
                   },
                   "name": {
                     "type": "string",
@@ -31316,9 +35602,8 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "description": "",
-                      "default": "revoked",
-                      "format": "The status of the token"
+                      "description": "The status of the token",
+                      "default": "revoked"
                     }
                   },
                   "required": [
@@ -31510,7 +35795,8 @@
                 "spy",
                 "typo",
                 "secret",
-                "obf"
+                "obf",
+                "dual"
               ],
               "default": "mal"
             }
@@ -31561,6 +35847,7 @@
                 "maven",
                 "npm",
                 "nuget",
+                "vscode",
                 "pypi",
                 "gem"
               ]
@@ -31645,6 +35932,11 @@
                             "type": "boolean",
                             "default": false,
                             "description": "Whether the threat still is in need of human review by the threat research team"
+                          },
+                          "threatInstanceId": {
+                            "type": "integer",
+                            "description": "Unique threat instance identifier across artifacts",
+                            "default": 0
                           }
                         },
                         "description": ""
@@ -31790,7 +36082,8 @@
                 "spy",
                 "typo",
                 "secret",
-                "obf"
+                "obf",
+                "dual"
               ],
               "default": "mal"
             }
@@ -31841,6 +36134,7 @@
                 "maven",
                 "npm",
                 "nuget",
+                "vscode",
                 "pypi",
                 "gem"
               ]
@@ -31925,6 +36219,11 @@
                             "type": "boolean",
                             "default": false,
                             "description": "Whether the threat still is in need of human review by the threat research team"
+                          },
+                          "threatInstanceId": {
+                            "type": "integer",
+                            "description": "Unique threat instance identifier across artifacts",
+                            "default": 0
                           }
                         },
                         "description": ""
@@ -31946,6 +36245,2240 @@
               }
             },
             "description": "The paginated list of items in the threat feed and the next page cursor."
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      }
+    },
+    "/orgs/{org_slug}/fixes": {
+      "get": {
+        "tags": [
+          "Fixes"
+        ],
+        "summary": "Fetch fixes for vulnerabilities in a repository or scan",
+        "operationId": "fetch-fixes",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repo_slug",
+            "in": "query",
+            "required": false,
+            "description": "The slug of the repository to fetch fixes for. Computes fixes based on the latest scan on the default branch",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "full_scan_id",
+            "in": "query",
+            "required": false,
+            "description": "The ID of the scan to fetch fixes for",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vulnerability_ids",
+            "in": "query",
+            "required": true,
+            "description": "Comma-separated list of GHSA or CVE IDs, or \"*\" for all vulnerabilities",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "allow_major_updates",
+            "in": "query",
+            "required": true,
+            "description": "Whether to allow major version updates in fixes",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "minimum_release_age",
+            "in": "query",
+            "required": false,
+            "description": "Minimum release age for fixes packages (e.g., \"1h\", \"2d\", \"1w\"). Higher values reduces risk of installing recently released untested package versions.",
+            "schema": {
+              "type": "string",
+              "default": "0d"
+            }
+          },
+          {
+            "name": "include_details",
+            "in": "query",
+            "required": false,
+            "description": "Whether to include advisory details in the response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "include_responsible_direct_dependencies",
+            "in": "query",
+            "required": false,
+            "description": "Set to include the direct dependencies responsible for introducing the dependency or dependencies with the vulnerability in the response",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+              "fixes:list"
+            ]
+          },
+          {
+            "basicAuth": [
+              "fixes:list"
+            ]
+          }
+        ],
+        "description": "Fetches available fixes for vulnerabilities in a repository or scan.\nRequires either repo_slug or full_scan_id as well as vulnerability_ids to be provided.\nvulnerability_ids can be a comma-separated list of GHSA or CVE IDs, or \"*\" for all vulnerabilities.\n\nThis endpoint consumes 10 units of your quota.\n\nThis endpoint requires the following org token scopes:\n- fixes:list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Response containing fix details for each requested vulnerability ID",
+                  "properties": {
+                    "fixDetails": {
+                      "type": "object",
+                      "description": "Map of vulnerability IDs (GHSA or CVE) to their fix details. Each entry contains information about available fixes, partial fixes, or reasons why fixes are not available.",
+                      "additionalProperties": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "value"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "fixFound"
+                                ]
+                              },
+                              "value": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "fixFound"
+                                    ],
+                                    "description": "",
+                                    "default": "fixFound"
+                                  },
+                                  "ghsa": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                  },
+                                  "cve": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "",
+                                    "nullable": true
+                                  },
+                                  "fixDetails": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fixes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "description": "",
+                                          "properties": {
+                                            "purl": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The PURL (unique package identifier) of the package to upgrade"
+                                            },
+                                            "fixedVersion": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The version of the package to upgrade to"
+                                            },
+                                            "manifestFiles": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string",
+                                                "description": "",
+                                                "default": "The manifest file(s) that contain the package"
+                                              },
+                                              "description": ""
+                                            },
+                                            "updateType": {
+                                              "type": "string",
+                                              "enum": [
+                                                "patch",
+                                                "minor",
+                                                "major",
+                                                "unknown"
+                                              ],
+                                              "description": "The type of version update (patch, minor, major, or unknown if it cannot be determined)",
+                                              "default": "unknown"
+                                            }
+                                          },
+                                          "required": [
+                                            "fixedVersion",
+                                            "manifestFiles",
+                                            "purl",
+                                            "updateType"
+                                          ]
+                                        },
+                                        "description": ""
+                                      },
+                                      "responsibleDirectDependencies": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "currentVersion": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "",
+                                              "format": "The current version of the package"
+                                            },
+                                            "nextAvailableVersion": {
+                                              "type": "object",
+                                              "additionalProperties": false,
+                                              "description": "",
+                                              "properties": {
+                                                "version": {
+                                                  "type": "string",
+                                                  "description": "",
+                                                  "default": "",
+                                                  "format": "The next available version of the package"
+                                                },
+                                                "updateType": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "patch",
+                                                    "minor",
+                                                    "major",
+                                                    "unknown"
+                                                  ],
+                                                  "description": "The type of version update (patch, minor, major, or unknown if it cannot be determined)",
+                                                  "default": "unknown"
+                                                }
+                                              },
+                                              "required": [
+                                                "updateType",
+                                                "version"
+                                              ],
+                                              "nullable": true
+                                            },
+                                            "fixByUpgradingTo": {
+                                              "type": "object",
+                                              "additionalProperties": false,
+                                              "description": "The version and update type of the package that is necessary to fix the vulnerability. If the value is null, it means the package does not have to be upgraded to fix the vulnerability",
+                                              "properties": {
+                                                "version": {
+                                                  "type": "string",
+                                                  "description": "",
+                                                  "default": ""
+                                                },
+                                                "updateType": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "patch",
+                                                    "minor",
+                                                    "major",
+                                                    "unknown"
+                                                  ],
+                                                  "description": "The type of version update (patch, minor, major, or unknown if it cannot be determined)",
+                                                  "default": "unknown"
+                                                }
+                                              },
+                                              "required": [
+                                                "updateType",
+                                                "version"
+                                              ],
+                                              "nullable": true
+                                            }
+                                          },
+                                          "required": [
+                                            "currentVersion"
+                                          ]
+                                        },
+                                        "properties": {},
+                                        "description": "The keys are the PURL (unique package identifier) of the direct dependency(ies) responsible for introducing the vulnerability.",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "fixes"
+                                    ]
+                                  },
+                                  "advisoryDetails": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "title": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "cwes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "description": "",
+                                          "default": ""
+                                        },
+                                        "description": ""
+                                      },
+                                      "severity": {
+                                        "type": "string",
+                                        "enum": [
+                                          "LOW",
+                                          "MODERATE",
+                                          "HIGH",
+                                          "CRITICAL"
+                                        ],
+                                        "description": "Severity level of the vulnerability",
+                                        "default": "LOW"
+                                      },
+                                      "cvssVector": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "publishedAt": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": ""
+                                      },
+                                      "kev": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the vulnerability is a Known Exploited Vulnerability"
+                                      },
+                                      "epss": {
+                                        "type": "number",
+                                        "description": "Exploit Prediction Scoring System score",
+                                        "default": 0,
+                                        "nullable": true
+                                      },
+                                      "affectedPurls": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "description": "",
+                                          "properties": {
+                                            "purl": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "",
+                                              "format": "The PURL (unique package identifier) of the affected package"
+                                            },
+                                            "affectedRange": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The range of vulnerable versions"
+                                            }
+                                          },
+                                          "required": [
+                                            "affectedRange",
+                                            "purl"
+                                          ]
+                                        },
+                                        "description": ""
+                                      }
+                                    },
+                                    "description": "",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "advisoryDetails",
+                                  "cve",
+                                  "fixDetails",
+                                  "ghsa",
+                                  "type"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "value"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "partialFixFound"
+                                ]
+                              },
+                              "value": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "partialFixFound"
+                                    ],
+                                    "description": "",
+                                    "default": "partialFixFound"
+                                  },
+                                  "ghsa": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                  },
+                                  "cve": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "",
+                                    "nullable": true
+                                  },
+                                  "fixDetails": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "fixes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "description": "",
+                                          "properties": {
+                                            "purl": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The PURL (unique package identifier) of the package to upgrade"
+                                            },
+                                            "fixedVersion": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The version of the package to upgrade to"
+                                            },
+                                            "manifestFiles": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string",
+                                                "description": "",
+                                                "default": "The manifest file(s) that contain the package"
+                                              },
+                                              "description": ""
+                                            },
+                                            "updateType": {
+                                              "type": "string",
+                                              "enum": [
+                                                "patch",
+                                                "minor",
+                                                "major",
+                                                "unknown"
+                                              ],
+                                              "description": "The type of version update (patch, minor, major, or unknown if it cannot be determined)",
+                                              "default": "unknown"
+                                            }
+                                          },
+                                          "required": [
+                                            "fixedVersion",
+                                            "manifestFiles",
+                                            "purl",
+                                            "updateType"
+                                          ]
+                                        },
+                                        "description": ""
+                                      },
+                                      "unfixablePurls": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "description": "",
+                                          "properties": {
+                                            "purl": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The PURL (unique package identifier) of the package that cannot be upgraded"
+                                            },
+                                            "manifestFiles": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string",
+                                                "description": "",
+                                                "default": "The manifest file(s) that contain the package"
+                                              },
+                                              "description": ""
+                                            }
+                                          },
+                                          "required": [
+                                            "manifestFiles",
+                                            "purl"
+                                          ]
+                                        },
+                                        "description": ""
+                                      },
+                                      "responsibleDirectDependencies": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "currentVersion": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "",
+                                              "format": "The current version of the package"
+                                            },
+                                            "nextAvailableVersion": {
+                                              "type": "object",
+                                              "additionalProperties": false,
+                                              "description": "",
+                                              "properties": {
+                                                "version": {
+                                                  "type": "string",
+                                                  "description": "",
+                                                  "default": "",
+                                                  "format": "The next available version of the package"
+                                                },
+                                                "updateType": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "patch",
+                                                    "minor",
+                                                    "major",
+                                                    "unknown"
+                                                  ],
+                                                  "description": "The type of version update (patch, minor, major, or unknown if it cannot be determined)",
+                                                  "default": "unknown"
+                                                }
+                                              },
+                                              "required": [
+                                                "updateType",
+                                                "version"
+                                              ],
+                                              "nullable": true
+                                            },
+                                            "fixByUpgradingTo": {
+                                              "type": "object",
+                                              "additionalProperties": false,
+                                              "description": "The version and update type of the package that is necessary to fix the vulnerability. If the value is null, it means the package does not have to be upgraded to fix the vulnerability",
+                                              "properties": {
+                                                "version": {
+                                                  "type": "string",
+                                                  "description": "",
+                                                  "default": ""
+                                                },
+                                                "updateType": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "patch",
+                                                    "minor",
+                                                    "major",
+                                                    "unknown"
+                                                  ],
+                                                  "description": "The type of version update (patch, minor, major, or unknown if it cannot be determined)",
+                                                  "default": "unknown"
+                                                }
+                                              },
+                                              "required": [
+                                                "updateType",
+                                                "version"
+                                              ],
+                                              "nullable": true
+                                            }
+                                          },
+                                          "required": [
+                                            "currentVersion"
+                                          ]
+                                        },
+                                        "properties": {},
+                                        "description": "The keys are the PURL (unique package identifier) of the direct dependency(ies) responsible for introducing the vulnerability.",
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "fixes",
+                                      "unfixablePurls"
+                                    ]
+                                  },
+                                  "advisoryDetails": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "title": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "cwes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "description": "",
+                                          "default": ""
+                                        },
+                                        "description": ""
+                                      },
+                                      "severity": {
+                                        "type": "string",
+                                        "enum": [
+                                          "LOW",
+                                          "MODERATE",
+                                          "HIGH",
+                                          "CRITICAL"
+                                        ],
+                                        "description": "Severity level of the vulnerability",
+                                        "default": "LOW"
+                                      },
+                                      "cvssVector": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "publishedAt": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": ""
+                                      },
+                                      "kev": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the vulnerability is a Known Exploited Vulnerability"
+                                      },
+                                      "epss": {
+                                        "type": "number",
+                                        "description": "Exploit Prediction Scoring System score",
+                                        "default": 0,
+                                        "nullable": true
+                                      },
+                                      "affectedPurls": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "description": "",
+                                          "properties": {
+                                            "purl": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "",
+                                              "format": "The PURL (unique package identifier) of the affected package"
+                                            },
+                                            "affectedRange": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The range of vulnerable versions"
+                                            }
+                                          },
+                                          "required": [
+                                            "affectedRange",
+                                            "purl"
+                                          ]
+                                        },
+                                        "description": ""
+                                      }
+                                    },
+                                    "description": "",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "advisoryDetails",
+                                  "cve",
+                                  "fixDetails",
+                                  "ghsa",
+                                  "type"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "value"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "errorComputingFix"
+                                ]
+                              },
+                              "value": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "errorComputingFix"
+                                    ],
+                                    "description": "",
+                                    "default": "errorComputingFix"
+                                  },
+                                  "ghsa": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "",
+                                    "nullable": true
+                                  },
+                                  "cve": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "",
+                                    "nullable": true
+                                  },
+                                  "message": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                  },
+                                  "advisoryDetails": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "title": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "cwes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "description": "",
+                                          "default": ""
+                                        },
+                                        "description": ""
+                                      },
+                                      "severity": {
+                                        "type": "string",
+                                        "enum": [
+                                          "LOW",
+                                          "MODERATE",
+                                          "HIGH",
+                                          "CRITICAL"
+                                        ],
+                                        "description": "Severity level of the vulnerability",
+                                        "default": "LOW"
+                                      },
+                                      "cvssVector": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "publishedAt": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": ""
+                                      },
+                                      "kev": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the vulnerability is a Known Exploited Vulnerability"
+                                      },
+                                      "epss": {
+                                        "type": "number",
+                                        "description": "Exploit Prediction Scoring System score",
+                                        "default": 0,
+                                        "nullable": true
+                                      },
+                                      "affectedPurls": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "description": "",
+                                          "properties": {
+                                            "purl": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "",
+                                              "format": "The PURL (unique package identifier) of the affected package"
+                                            },
+                                            "affectedRange": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The range of vulnerable versions"
+                                            }
+                                          },
+                                          "required": [
+                                            "affectedRange",
+                                            "purl"
+                                          ]
+                                        },
+                                        "description": ""
+                                      }
+                                    },
+                                    "description": "",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "advisoryDetails",
+                                  "cve",
+                                  "ghsa",
+                                  "message",
+                                  "type"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "value"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "noFixAvailable"
+                                ]
+                              },
+                              "value": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "noFixAvailable"
+                                    ],
+                                    "description": "",
+                                    "default": "noFixAvailable"
+                                  },
+                                  "ghsa": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                  },
+                                  "cve": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "",
+                                    "nullable": true
+                                  },
+                                  "advisoryDetails": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "title": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "cwes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "description": "",
+                                          "default": ""
+                                        },
+                                        "description": ""
+                                      },
+                                      "severity": {
+                                        "type": "string",
+                                        "enum": [
+                                          "LOW",
+                                          "MODERATE",
+                                          "HIGH",
+                                          "CRITICAL"
+                                        ],
+                                        "description": "Severity level of the vulnerability",
+                                        "default": "LOW"
+                                      },
+                                      "cvssVector": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "publishedAt": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": ""
+                                      },
+                                      "kev": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the vulnerability is a Known Exploited Vulnerability"
+                                      },
+                                      "epss": {
+                                        "type": "number",
+                                        "description": "Exploit Prediction Scoring System score",
+                                        "default": 0,
+                                        "nullable": true
+                                      },
+                                      "affectedPurls": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "description": "",
+                                          "properties": {
+                                            "purl": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "",
+                                              "format": "The PURL (unique package identifier) of the affected package"
+                                            },
+                                            "affectedRange": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The range of vulnerable versions"
+                                            }
+                                          },
+                                          "required": [
+                                            "affectedRange",
+                                            "purl"
+                                          ]
+                                        },
+                                        "description": ""
+                                      }
+                                    },
+                                    "description": "",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "advisoryDetails",
+                                  "cve",
+                                  "ghsa",
+                                  "type"
+                                ]
+                              }
+                            }
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "value"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "fixNotApplicable"
+                                ]
+                              },
+                              "value": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "fixNotApplicable"
+                                    ],
+                                    "description": "",
+                                    "default": "fixNotApplicable"
+                                  },
+                                  "ghsa": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": ""
+                                  },
+                                  "cve": {
+                                    "type": "string",
+                                    "description": "",
+                                    "default": "",
+                                    "nullable": true
+                                  },
+                                  "advisoryDetails": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "title": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "description": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "cwes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "description": "",
+                                          "default": ""
+                                        },
+                                        "description": ""
+                                      },
+                                      "severity": {
+                                        "type": "string",
+                                        "enum": [
+                                          "LOW",
+                                          "MODERATE",
+                                          "HIGH",
+                                          "CRITICAL"
+                                        ],
+                                        "description": "Severity level of the vulnerability",
+                                        "default": "LOW"
+                                      },
+                                      "cvssVector": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": "",
+                                        "nullable": true
+                                      },
+                                      "publishedAt": {
+                                        "type": "string",
+                                        "description": "",
+                                        "default": ""
+                                      },
+                                      "kev": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the vulnerability is a Known Exploited Vulnerability"
+                                      },
+                                      "epss": {
+                                        "type": "number",
+                                        "description": "Exploit Prediction Scoring System score",
+                                        "default": 0,
+                                        "nullable": true
+                                      },
+                                      "affectedPurls": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "additionalProperties": false,
+                                          "description": "",
+                                          "properties": {
+                                            "purl": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "",
+                                              "format": "The PURL (unique package identifier) of the affected package"
+                                            },
+                                            "affectedRange": {
+                                              "type": "string",
+                                              "description": "",
+                                              "default": "The range of vulnerable versions"
+                                            }
+                                          },
+                                          "required": [
+                                            "affectedRange",
+                                            "purl"
+                                          ]
+                                        },
+                                        "description": ""
+                                      }
+                                    },
+                                    "description": "",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "advisoryDetails",
+                                  "cve",
+                                  "ghsa",
+                                  "type"
+                                ]
+                              }
+                            }
+                          }
+                        ],
+                        "discriminator": {
+                          "propertyName": "type"
+                        }
+                      },
+                      "properties": {}
+                    }
+                  },
+                  "required": [
+                    "fixDetails"
+                  ]
+                }
+              }
+            },
+            "description": "Fix details for requested vulnerabilities"
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      }
+    },
+    "/orgs/{org_slug}/telemetry/config": {
+      "get": {
+        "tags": [
+          "Telemetry"
+        ],
+        "summary": "Get Organization Telemetry Config",
+        "operationId": "getOrgTelemetryConfig",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Retrieve the telemetry config of an organization.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "",
+                  "properties": {
+                    "telemetry": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Telemetry configuration",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean",
+                          "default": false,
+                          "description": "Telemetry enabled"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "telemetry"
+                  ]
+                }
+              }
+            },
+            "description": "Retrieved telemetry config details"
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      },
+      "put": {
+        "tags": [
+          "Telemetry"
+        ],
+        "summary": "Update Telemetry Config",
+        "operationId": "updateOrgTelemetryConfig",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Telemetry enabled"
+                  }
+                },
+                "description": ""
+              }
+            }
+          },
+          "required": false
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "telemetry-policy:update"
+            ]
+          },
+          {
+            "basicAuth": [
+              "telemetry-policy:update"
+            ]
+          }
+        ],
+        "description": "Update the telemetry config of an organization.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- telemetry-policy:update",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "",
+                  "properties": {
+                    "telemetry": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Telemetry configuration",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean",
+                          "default": false,
+                          "description": "Telemetry enabled"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "telemetry"
+                  ]
+                }
+              }
+            },
+            "description": "Updated telemetry config details"
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      }
+    },
+    "/orgs/{org_slug}/webhooks": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "List all webhooks",
+        "externalDocs": {
+          "description": "Webhooks documentation",
+          "url": "https://docs.socket.dev/docs/webhooks"
+        },
+        "operationId": "getOrgWebhooksList",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "",
+            "schema": {
+              "type": "string",
+              "default": "created_at"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "required": false,
+            "description": "",
+            "schema": {
+              "type": "string",
+              "default": "desc"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 30
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+              "webhooks:list"
+            ]
+          },
+          {
+            "basicAuth": [
+              "webhooks:list"
+            ]
+          }
+        ],
+        "description": "List all webhooks in the specified organization.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- webhooks:list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "The ID of the webhook",
+                            "default": ""
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "description": "The creation date of the webhook",
+                            "default": ""
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "description": "The last update date of the webhook",
+                            "default": ""
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "The name of the webhook",
+                            "default": ""
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "The description of the webhook",
+                            "default": "",
+                            "nullable": true
+                          },
+                          "url": {
+                            "type": "string",
+                            "description": "The URL where webhook events will be sent",
+                            "default": ""
+                          },
+                          "secret": {
+                            "type": "string",
+                            "description": "The signing key used to sign webhook payloads",
+                            "default": "",
+                            "nullable": true
+                          },
+                          "events": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "description": "The event types to subscribe to",
+                              "default": ""
+                            },
+                            "description": "Array of event names"
+                          },
+                          "headers": {
+                            "type": "object",
+                            "description": "Custom headers to include in webhook requests",
+                            "default": null,
+                            "nullable": true
+                          },
+                          "filters": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "",
+                            "properties": {
+                              "repositoryIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "description": "Repository IDs to filter events",
+                                  "default": ""
+                                },
+                                "description": "Array of repository IDs",
+                                "nullable": true
+                              }
+                            },
+                            "required": [
+                              "repositoryIds"
+                            ],
+                            "nullable": true
+                          }
+                        },
+                        "required": [
+                          "created_at",
+                          "description",
+                          "events",
+                          "filters",
+                          "headers",
+                          "id",
+                          "name",
+                          "secret",
+                          "updated_at",
+                          "url"
+                        ]
+                      },
+                      "description": ""
+                    },
+                    "nextPage": {
+                      "type": "integer",
+                      "description": "",
+                      "default": 0,
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "nextPage",
+                    "results"
+                  ]
+                }
+              }
+            },
+            "description": "List of webhooks"
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      },
+      "post": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Create a webhook",
+        "externalDocs": {
+          "description": "Webhooks documentation",
+          "url": "https://docs.socket.dev/docs/webhooks"
+        },
+        "operationId": "createOrgWebhook",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the webhook",
+                    "default": ""
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "The URL where webhook events will be sent",
+                    "default": ""
+                  },
+                  "secret": {
+                    "type": "string",
+                    "description": "The signing key used to sign webhook payloads",
+                    "default": ""
+                  },
+                  "events": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The event types to subscribe to",
+                      "default": ""
+                    },
+                    "description": "Array of event names"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The description of the webhook",
+                    "default": "",
+                    "nullable": true
+                  },
+                  "headers": {
+                    "type": "object",
+                    "description": "Custom headers to include in webhook requests",
+                    "default": null,
+                    "nullable": true
+                  },
+                  "filters": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "description": "",
+                    "properties": {
+                      "repositoryIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "description": "Repository IDs to filter events",
+                          "default": ""
+                        },
+                        "description": "Array of repository IDs",
+                        "nullable": true
+                      }
+                    },
+                    "required": [
+                      "repositoryIds"
+                    ],
+                    "nullable": true
+                  }
+                },
+                "required": [
+                  "events",
+                  "name",
+                  "secret",
+                  "url"
+                ]
+              }
+            }
+          },
+          "required": false
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "webhooks:create"
+            ]
+          },
+          {
+            "basicAuth": [
+              "webhooks:create"
+            ]
+          }
+        ],
+        "description": "Create a new webhook. Returns the created webhook details.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- webhooks:create",
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The ID of the webhook",
+                      "default": ""
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "description": "The creation date of the webhook",
+                      "default": ""
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "description": "The last update date of the webhook",
+                      "default": ""
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the webhook",
+                      "default": ""
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The description of the webhook",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "The URL where webhook events will be sent",
+                      "default": ""
+                    },
+                    "secret": {
+                      "type": "string",
+                      "description": "The signing key used to sign webhook payloads",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "The event types to subscribe to",
+                        "default": ""
+                      },
+                      "description": "Array of event names"
+                    },
+                    "headers": {
+                      "type": "object",
+                      "description": "Custom headers to include in webhook requests",
+                      "default": null,
+                      "nullable": true
+                    },
+                    "filters": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "",
+                      "properties": {
+                        "repositoryIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "description": "Repository IDs to filter events",
+                            "default": ""
+                          },
+                          "description": "Array of repository IDs",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "repositoryIds"
+                      ],
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "created_at",
+                    "description",
+                    "events",
+                    "filters",
+                    "headers",
+                    "id",
+                    "name",
+                    "secret",
+                    "updated_at",
+                    "url"
+                  ]
+                }
+              }
+            },
+            "description": "The created webhook"
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      }
+    },
+    "/orgs/{org_slug}/webhooks/{webhook_id}": {
+      "get": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Get webhook",
+        "externalDocs": {
+          "description": "Webhooks documentation",
+          "url": "https://docs.socket.dev/docs/webhooks"
+        },
+        "operationId": "getOrgWebhook",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the webhook",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+              "webhooks:list"
+            ]
+          },
+          {
+            "basicAuth": [
+              "webhooks:list"
+            ]
+          }
+        ],
+        "description": "Get a webhook for the specified organization.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- webhooks:list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The ID of the webhook",
+                      "default": ""
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "description": "The creation date of the webhook",
+                      "default": ""
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "description": "The last update date of the webhook",
+                      "default": ""
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the webhook",
+                      "default": ""
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The description of the webhook",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "The URL where webhook events will be sent",
+                      "default": ""
+                    },
+                    "secret": {
+                      "type": "string",
+                      "description": "The signing key used to sign webhook payloads",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "The event types to subscribe to",
+                        "default": ""
+                      },
+                      "description": "Array of event names"
+                    },
+                    "headers": {
+                      "type": "object",
+                      "description": "Custom headers to include in webhook requests",
+                      "default": null,
+                      "nullable": true
+                    },
+                    "filters": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "",
+                      "properties": {
+                        "repositoryIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "description": "Repository IDs to filter events",
+                            "default": ""
+                          },
+                          "description": "Array of repository IDs",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "repositoryIds"
+                      ],
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "created_at",
+                    "description",
+                    "events",
+                    "filters",
+                    "headers",
+                    "id",
+                    "name",
+                    "secret",
+                    "updated_at",
+                    "url"
+                  ]
+                }
+              }
+            },
+            "description": "Webhook details"
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      },
+      "put": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Update webhook",
+        "externalDocs": {
+          "description": "Webhooks documentation",
+          "url": "https://docs.socket.dev/docs/webhooks"
+        },
+        "operationId": "updateOrgWebhook",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the webhook",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the webhook",
+                    "default": ""
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The description of the webhook",
+                    "default": "",
+                    "nullable": true
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "The URL where webhook events will be sent",
+                    "default": ""
+                  },
+                  "secret": {
+                    "type": "string",
+                    "description": "The signing key used to sign webhook payloads",
+                    "default": "",
+                    "nullable": true
+                  },
+                  "events": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "description": "The event types to subscribe to",
+                      "default": ""
+                    },
+                    "description": "Array of event names"
+                  },
+                  "headers": {
+                    "type": "object",
+                    "description": "Custom headers to include in webhook requests",
+                    "default": null,
+                    "nullable": true
+                  },
+                  "filters": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "description": "",
+                    "properties": {
+                      "repositoryIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "description": "Repository IDs to filter events",
+                          "default": ""
+                        },
+                        "description": "Array of repository IDs",
+                        "nullable": true
+                      }
+                    },
+                    "required": [
+                      "repositoryIds"
+                    ],
+                    "nullable": true
+                  }
+                },
+                "description": ""
+              }
+            }
+          },
+          "required": false
+        },
+        "security": [
+          {
+            "bearerAuth": [
+              "webhooks:update"
+            ]
+          },
+          {
+            "basicAuth": [
+              "webhooks:update"
+            ]
+          }
+        ],
+        "description": "Update details of an existing webhook.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- webhooks:update",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "The ID of the webhook",
+                      "default": ""
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "description": "The creation date of the webhook",
+                      "default": ""
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "description": "The last update date of the webhook",
+                      "default": ""
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the webhook",
+                      "default": ""
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The description of the webhook",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "The URL where webhook events will be sent",
+                      "default": ""
+                    },
+                    "secret": {
+                      "type": "string",
+                      "description": "The signing key used to sign webhook payloads",
+                      "default": "",
+                      "nullable": true
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "The event types to subscribe to",
+                        "default": ""
+                      },
+                      "description": "Array of event names"
+                    },
+                    "headers": {
+                      "type": "object",
+                      "description": "Custom headers to include in webhook requests",
+                      "default": null,
+                      "nullable": true
+                    },
+                    "filters": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "",
+                      "properties": {
+                        "repositoryIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "description": "Repository IDs to filter events",
+                            "default": ""
+                          },
+                          "description": "Array of repository IDs",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "repositoryIds"
+                      ],
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "created_at",
+                    "description",
+                    "events",
+                    "filters",
+                    "headers",
+                    "id",
+                    "name",
+                    "secret",
+                    "updated_at",
+                    "url"
+                  ]
+                }
+              }
+            },
+            "description": "Updated webhook details"
+          },
+          "400": {
+            "$ref": "#/components/responses/SocketBadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/SocketUnauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/SocketForbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/SocketNotFoundResponse"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      },
+      "delete": {
+        "tags": [
+          "Webhooks"
+        ],
+        "summary": "Delete webhook",
+        "externalDocs": {
+          "description": "Webhooks documentation",
+          "url": "https://docs.socket.dev/docs/webhooks"
+        },
+        "operationId": "deleteOrgWebhook",
+        "parameters": [
+          {
+            "name": "org_slug",
+            "in": "path",
+            "required": true,
+            "description": "The slug of the organization",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the webhook",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": [
+              "webhooks:delete"
+            ]
+          },
+          {
+            "basicAuth": [
+              "webhooks:delete"
+            ]
+          }
+        ],
+        "description": "Delete a webhook. This will stop all future webhook deliveries to the webhook URL.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:\n- webhooks:delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "",
+                      "default": "ok"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            },
+            "description": "Success"
           },
           "400": {
             "$ref": "#/components/responses/SocketBadRequest"
@@ -32399,6 +38932,29 @@
         ],
         "summary": "Returns the OpenAPI definition",
         "operationId": "getOpenAPI",
+        "security": [],
+        "description": "Retrieve the API specification in an Openapi JSON format.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {}
+            },
+            "description": "OpenAPI specification"
+          },
+          "429": {
+            "$ref": "#/components/responses/SocketTooManyRequestsResponse"
+          }
+        },
+        "x-readme": {}
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "tags": [
+          "Metadata"
+        ],
+        "summary": "Returns the OpenAPI definition",
+        "operationId": "getOpenAPIJSON",
         "security": [],
         "description": "Retrieve the API specification in an Openapi JSON format.\n\nThis endpoint consumes 1 unit of your quota.\n\nThis endpoint requires the following org token scopes:",
         "responses": {
@@ -32978,6 +39534,17 @@
         "summary": "Create a report",
         "deprecated": true,
         "operationId": "createReport",
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "query",
+            "required": false,
+            "description": "The workspace of the repository to associate the full-scan with.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "multipart/form-data": {
@@ -33222,6 +39789,11 @@
                             "default": "",
                             "nullable": true
                           },
+                          "workspace": {
+                            "type": "string",
+                            "description": "",
+                            "default": ""
+                          },
                           "latest_project_report": {
                             "type": "object",
                             "additionalProperties": false,
@@ -33252,7 +39824,8 @@
                           "id",
                           "name",
                           "organization_id",
-                          "updated_at"
+                          "updated_at",
+                          "workspace"
                         ]
                       },
                       "description": ""

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -17,7 +17,7 @@ function runCommand(command, args = []) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: 'inherit',
-      shell: process.platform === 'win32',
+      shell: process.platform === 'win32'
     })
 
     child.on('exit', code => {
@@ -40,7 +40,7 @@ async function main() {
       '-c',
       '--aggregate-output',
       'check:lint',
-      'check:tsc',
+      'check:tsc'
     ])
 
     process.exitCode = exitCode

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -22,7 +22,7 @@ function parseArgs() {
     all: args.includes('--all'),
     help: args.includes('--help') || args.includes('-h'),
     // Get remaining positional arguments (file paths)
-    files: args.filter(arg => !arg.startsWith('--') && !arg.startsWith('-')),
+    files: args.filter(arg => !arg.startsWith('--') && !arg.startsWith('-'))
   }
 }
 
@@ -33,7 +33,7 @@ function runCommand(command, args = []) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: 'inherit',
-      shell: process.platform === 'win32',
+      shell: process.platform === 'win32'
     })
 
     child.on('exit', code => {
@@ -76,7 +76,7 @@ async function main() {
       'oxlint',
       '-c=.oxlintrc.json',
       '--ignore-path=.oxlintignore',
-      '--tsconfig=tsconfig.json',
+      '--tsconfig=tsconfig.json'
     ]
 
     // Add fix flag if requested
@@ -101,7 +101,17 @@ async function main() {
     const useEnvFile = existsSync('.env.local')
     let exitCode
     if (useEnvFile) {
-      exitCode = await runCommand('pnpm', ['exec', 'dotenvx', '-q', 'run', '-f', '.env.local', '--', 'pnpm', ...oxlintArgs])
+      exitCode = await runCommand('pnpm', [
+        'exec',
+        'dotenvx',
+        '-q',
+        'run',
+        '-f',
+        '.env.local',
+        '--',
+        'pnpm',
+        ...oxlintArgs
+      ])
     } else {
       exitCode = await runCommand('pnpm', oxlintArgs)
     }

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -16,7 +16,7 @@ function runCommand(command, args = [], options = {}) {
     const child = spawn(command, args, {
       stdio: 'inherit',
       shell: process.platform === 'win32',
-      ...options,
+      ...options
     })
 
     child.on('exit', code => {
@@ -35,31 +35,32 @@ async function main() {
       options: {
         help: {
           type: 'boolean',
-          default: false,
+          default: false
         },
         'dry-run': {
           type: 'boolean',
-          default: false,
+          default: false
         },
         'skip-checks': {
           type: 'boolean',
-          default: false,
+          default: false
         },
         'skip-build': {
           type: 'boolean',
-          default: false,
+          default: false
         },
         tag: {
           type: 'string',
-          default: process.env.DIST_TAG || process.env.NPM_CONFIG_TAG || 'latest',
+          default:
+            process.env.DIST_TAG || process.env.NPM_CONFIG_TAG || 'latest'
         },
         access: {
           type: 'string',
-          default: 'public',
-        },
+          default: 'public'
+        }
       },
       allowPositionals: false,
-      strict: false,
+      strict: false
     })
 
     if (values.help) {
@@ -69,7 +70,9 @@ async function main() {
       console.log('  --dry-run        Perform a dry-run without publishing')
       console.log('  --skip-checks    Skip pre-publish checks')
       console.log('  --skip-build     Skip build step (not allowed in CI)')
-      console.log('  --tag <tag>      npm dist-tag (default: $DIST_TAG or "latest")')
+      console.log(
+        '  --tag <tag>      npm dist-tag (default: $DIST_TAG or "latest")'
+      )
       console.log('  --access <level> Package access level (default: public)')
       console.log('\nEnvironment Variables:')
       console.log('  DIST_TAG         Default npm dist-tag to use')
@@ -121,7 +124,13 @@ async function main() {
     }
 
     // Prepare publish args
-    const publishArgs = ['publish', '--access', values.access, '--tag', values.tag]
+    const publishArgs = [
+      'publish',
+      '--access',
+      values.access,
+      '--tag',
+      values.tag
+    ]
 
     // Add provenance by default (works with trusted publishers in CI)
     if (!values['dry-run']) {
@@ -136,7 +145,7 @@ async function main() {
     console.log(
       values['dry-run']
         ? 'Running dry-run publish...'
-        : `Publishing to npm with tag "${values.tag}"...`,
+        : `Publishing to npm with tag "${values.tag}"...`
     )
     const publishCode = await runCommand('npm', publishArgs)
 

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -26,10 +26,15 @@ function parseArgs() {
     // Get remaining arguments to pass to vitest
     extra: args.filter(
       arg =>
-        !['--all', '--update', '--coverage', '--cover', '--help', '-h'].includes(
-          arg,
-        ),
-    ),
+        ![
+          '--all',
+          '--update',
+          '--coverage',
+          '--cover',
+          '--help',
+          '-h'
+        ].includes(arg)
+    )
   }
 }
 
@@ -40,7 +45,7 @@ function runCommand(command, args = []) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: 'inherit',
-      shell: process.platform === 'win32',
+      shell: process.platform === 'win32'
     })
 
     child.on('exit', code => {
@@ -82,7 +87,13 @@ async function main() {
 
     // Step 1: Run checks
     console.log('Running checks...')
-    let exitCode = await runCommand('pnpm', ['exec', 'run-p', '-c', '--aggregate-output', 'check:*'])
+    let exitCode = await runCommand('pnpm', [
+      'exec',
+      'run-p',
+      '-c',
+      '--aggregate-output',
+      'check:*'
+    ])
     if (exitCode !== 0) {
       console.error('Checks failed')
       process.exitCode = exitCode
@@ -92,7 +103,18 @@ async function main() {
     // Step 2: Run test:prepare (build)
     console.log('\nPreparing tests (building)...')
     if (useEnvFile) {
-      exitCode = await runCommand('pnpm', ['exec', 'dotenvx', '-q', 'run', '-f', '.env.test', '--', 'pnpm', 'run', 'build'])
+      exitCode = await runCommand('pnpm', [
+        'exec',
+        'dotenvx',
+        '-q',
+        'run',
+        '-f',
+        '.env.test',
+        '--',
+        'pnpm',
+        'run',
+        'build'
+      ])
     } else {
       exitCode = await runCommand('pnpm', ['run', 'build'])
     }
@@ -122,7 +144,17 @@ async function main() {
     }
 
     if (useEnvFile) {
-      exitCode = await runCommand('pnpm', ['exec', 'dotenvx', '-q', 'run', '-f', '.env.test', '--', 'pnpm', ...vitestArgs])
+      exitCode = await runCommand('pnpm', [
+        'exec',
+        'dotenvx',
+        '-q',
+        'run',
+        '-f',
+        '.env.test',
+        '--',
+        'pnpm',
+        ...vitestArgs
+      ])
     } else {
       exitCode = await runCommand('pnpm', vitestArgs)
     }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -57,4 +57,63 @@ describe('SocketSdk', () => {
       })
     })
   })
+
+  describe('getTelemetryConfig', () => {
+    it('should get telemetry config', async () => {
+      nock('https://api.socket.dev')
+        .get('/v0/orgs/test-org/telemetry/config')
+        .reply(200, { telemetry: { enabled: false } })
+
+      const client = new SocketSdk('yetAnotherApiKey')
+      const res = await client.getTelemetryConfig('test-org')
+
+      expect(res).toEqual({
+        success: true,
+        status: 200,
+        data: { telemetry: { enabled: false } }
+      })
+    })
+  })
+
+  describe('updateOrgTelemetryConfig', () => {
+    it('should update telemetry config', async () => {
+      nock('https://api.socket.dev')
+        .put('/v0/orgs/test-org/telemetry/config', { enabled: true })
+        .reply(200, { telemetry: { enabled: true } })
+
+      const client = new SocketSdk('yetAnotherApiKey')
+      const res = await client.updateOrgTelemetryConfig('test-org', {
+        enabled: true
+      })
+
+      expect(res).toEqual({
+        success: true,
+        status: 200,
+        data: { telemetry: { enabled: true } }
+      })
+    })
+  })
+
+  describe('postOrgTelemetry', () => {
+    it('should post telemetry data', async () => {
+      nock('https://api.socket.dev')
+        .post('/v0/orgs/test-org/telemetry', {
+          event: 'test-event',
+          timestamp: 1234567890
+        })
+        .reply(200, {})
+
+      const client = new SocketSdk('yetAnotherApiKey')
+      const res = await client.postOrgTelemetry('test-org', {
+        event: 'test-event',
+        timestamp: 1234567890
+      })
+
+      expect(res).toEqual({
+        success: true,
+        status: 200,
+        data: {}
+      })
+    })
+  })
 })

--- a/test/socket-sdk-logging-hooks.test.ts
+++ b/test/socket-sdk-logging-hooks.test.ts
@@ -13,7 +13,7 @@ describe('SocketSdk - Logging Hooks', () => {
     const onResponse = vi.fn()
 
     const client = new SocketSdk('test-token', {
-      hooks: { onRequest, onResponse },
+      hooks: { onRequest, onResponse }
     })
 
     // Mock successful quota API call
@@ -28,7 +28,7 @@ describe('SocketSdk - Logging Hooks', () => {
     const requestInfo: RequestInfo = onRequest.mock.calls[0]?.[0]!
     expect(requestInfo).toMatchObject({
       method: 'GET',
-      url: 'https://api.socket.dev/v0/quota',
+      url: 'https://api.socket.dev/v0/quota'
     })
     expect(requestInfo.headers).toBeDefined()
 
@@ -38,7 +38,7 @@ describe('SocketSdk - Logging Hooks', () => {
     expect(responseInfo).toMatchObject({
       method: 'GET',
       url: 'https://api.socket.dev/v0/quota',
-      status: 200,
+      status: 200
     })
     expect(responseInfo.duration).toBeGreaterThanOrEqual(0)
     expect(responseInfo.headers).toBeDefined()
@@ -49,7 +49,7 @@ describe('SocketSdk - Logging Hooks', () => {
     const onResponse = vi.fn()
 
     const client = new SocketSdk('test-token', {
-      hooks: { onRequest, onResponse },
+      hooks: { onRequest, onResponse }
     })
 
     // Mock network error
@@ -67,7 +67,7 @@ describe('SocketSdk - Logging Hooks', () => {
     const responseInfo: ResponseInfo = onResponse.mock.calls[0]?.[0]!
     expect(responseInfo).toMatchObject({
       method: 'GET',
-      url: 'https://api.socket.dev/v0/quota',
+      url: 'https://api.socket.dev/v0/quota'
     })
     expect(responseInfo.error).toBeInstanceOf(Error)
     expect(responseInfo.duration).toBeGreaterThanOrEqual(0)
@@ -78,16 +78,20 @@ describe('SocketSdk - Logging Hooks', () => {
     const onResponse = vi.fn()
 
     const client = new SocketSdk('test-token', {
-      hooks: { onRequest, onResponse },
+      hooks: { onRequest, onResponse }
     })
 
     // Mock successful API call
     nock('https://api.socket.dev')
       .get('/v0/quota')
-      .reply(200, { quota: { remaining: 100 } }, {
-        'set-cookie': 'session=secret123',
-        'content-type': 'application/json',
-      })
+      .reply(
+        200,
+        { quota: { remaining: 100 } },
+        {
+          'set-cookie': 'session=secret123',
+          'content-type': 'application/json'
+        }
+      )
 
     await client.getQuota()
 


### PR DESCRIPTION
This PR adds telemetry endpoints. 

Following the doc, running `pnpm run generate-sdk` seems to have updated a bunch of linting/format rules. 

I can cherry pick the changes related to telemetry.


(stable telemetry release is here: https://github.com/SocketDev/socket-sdk-js/pull/445)