### PR TITLE
perf(build): bundle all deps and stub heavy internals

### DIFF
--- a/.config/esbuild.config.mjs
+++ b/.config/esbuild.config.mjs
@@ -206,6 +206,56 @@ function createNodeProtocolPlugin() {
   }
 }
 
+/**
+ * Plugin to stub heavy @socketsecurity/lib internals and third-party modules
+ * that are unreachable or safely degradable in the SDK's runtime code paths.
+ *
+ * @socketsecurity/lib stubs:
+ *
+ *   npm-pack.js (2.5MB) — arborist, cacache, pacote, make-fetch-happen,
+ *     semver. Reached via sorts→semver (dead) and cache-with-ttl→cacache
+ *     (degrades gracefully: safeGet returns undefined, in-memory memoization
+ *     still works).
+ *
+ *   pico-pack.js (260KB) — picomatch, fast-glob, del. Reached via
+ *     fs→globs for isDirEmptySync/readDirNames, never called by SDK.
+ *
+ *   globs.js, sorts.js — gateway modules to pico-pack and npm-pack.
+ *
+ * Third-party stubs:
+ *
+ *   mime-db (212KB) — Massive MIME type database bundled via form-data →
+ *     mime-types → mime-db. The SDK only uses 'application/octet-stream'
+ *     (file uploads) and 'application/json' (API calls). Replaced with a
+ *     minimal lookup covering just those types.
+ */
+function createLibStubPlugin() {
+  const libStubPattern =
+    /@socketsecurity\/lib\/dist\/(globs|sorts|external\/(npm-pack|pico-pack))\.js$/
+
+  const mimeDbPattern = /mime-db\/db\.json$/
+
+  return {
+    name: 'stub-unused-internals',
+    setup(build) {
+      // Stub heavy lib modules with empty exports.
+      build.onLoad({ filter: libStubPattern }, () => ({
+        contents: 'module.exports = {}',
+        loader: 'js',
+      }))
+      // Replace 212KB mime-db with minimal lookup for types the SDK uses.
+      build.onLoad({ filter: mimeDbPattern }, () => ({
+        contents: `module.exports = {
+  "application/json": { source: "iana", charset: "UTF-8", compressible: true },
+  "application/octet-stream": { source: "iana", compressible: false },
+  "multipart/form-data": { source: "iana" }
+}`,
+        loader: 'js',
+      }))
+    },
+  }
+}
+
 // Build configuration for ESM output
 export const buildConfig = {
   entryPoints: [`${srcPath}/index.ts`, `${srcPath}/testing.ts`],
@@ -226,9 +276,11 @@ export const buildConfig = {
   logLevel: 'info',
 
   // Use plugins for module resolution and path handling.
-  plugins: [createNodeProtocolPlugin(), createPathShorteningPlugin()].filter(
-    Boolean,
-  ),
+  plugins: [
+    createLibStubPlugin(),
+    createNodeProtocolPlugin(),
+    createPathShorteningPlugin(),
+  ].filter(Boolean),
 
   // External dependencies.
   // All runtime dependencies from package.json are external (not bundled) - consumers must install them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@
 - Dependencies: After `package.json` edits, run `pnpm install` to update `pnpm-lock.yaml`
 - Backward Compatibility: 🚨 FORBIDDEN to maintain - actively remove when encountered (see canonical CLAUDE.md)
 - 🚨 **NEVER use `npx`, `pnpm dlx`, or `yarn dlx`** — use `pnpm exec <package>` for devDep binaries, or `pnpm run <script>` for package.json scripts. If a tool is needed, add it as a pinned devDependency first.
+- **minimumReleaseAge**: NEVER add packages to `minimumReleaseAgeExclude` in CI. Locally, ASK before adding — the age threshold is a security control.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -64,12 +64,9 @@
     "type": "tsgo --noEmit -p .config/tsconfig.check.json",
     "update": "node scripts/update.mjs"
   },
-  "dependencies": {
-    "@socketsecurity/lib": "5.15.0",
-    "form-data": "4.0.5"
-  },
   "devDependencies": {
     "@anthropic-ai/claude-code": "2.1.92",
+    "@socketsecurity/lib": "5.18.2",
     "@babel/generator": "7.28.5",
     "@babel/parser": "7.26.3",
     "@babel/traverse": "7.26.4",
@@ -87,6 +84,7 @@
     "ecc-agentshield": "1.4.0",
     "esbuild": "0.25.11",
     "fast-glob": "3.3.3",
+    "form-data": "4.0.5",
     "husky": "9.1.7",
     "magic-string": "0.30.14",
     "nock": "14.0.10",
@@ -120,7 +118,7 @@
       "unrs-resolver"
     ],
     "overrides": {
-      "defu": ">=6.1.6",
+      "defu": ">=6.1.7",
       "vite": "7.3.2"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,19 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  defu: '>=6.1.6'
+  defu: '>=6.1.7'
   vite: 7.3.2
 
 importers:
 
   .:
-    dependencies:
-      '@socketsecurity/lib':
-        specifier: 5.15.0
-        version: 5.15.0(typescript@5.9.3)
-      form-data:
-        specifier: 4.0.5
-        version: 4.0.5
     devDependencies:
       '@anthropic-ai/claude-code':
         specifier: 2.1.92
@@ -40,6 +33,9 @@ importers:
       '@oxlint/migrate':
         specifier: 1.52.0
         version: 1.52.0
+      '@socketsecurity/lib':
+        specifier: 5.18.2
+        version: 5.18.2(typescript@5.9.3)
       '@sveltejs/acorn-typescript':
         specifier: 1.0.8
         version: 1.0.8(acorn@8.15.0)
@@ -73,6 +69,9 @@ importers:
       fast-glob:
         specifier: 3.3.3
         version: 3.3.3
+      form-data:
+        specifier: 4.0.5
+        version: 4.0.5
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -1183,9 +1182,9 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
-  '@socketsecurity/lib@5.15.0':
-    resolution: {integrity: sha512-+I7+lR0WBCXWgRxMTQx+N70azONVGr68ndi25pz53D6QLdIQ8gfBgOgC34opECXL9lPUqVCMYNr3XFS/bHABIQ==}
-    engines: {node: '>=22', pnpm: '>=10.25.0'}
+  '@socketsecurity/lib@5.18.2':
+    resolution: {integrity: sha512-h6aGfphQ9jdVjUMGIKJcsIvT6BmzBo0OD20HzeK+6KQJi2HupfCUzIH26vDPxf+aYVmrX0/hKJDYI5sXfTGx9A==}
+    engines: {node: '>=22', pnpm: '>=11.0.0-rc.0'}
     peerDependencies:
       typescript: '>=5.0.0'
     peerDependenciesMeta:
@@ -1433,8 +1432,8 @@ packages:
     resolution: {integrity: sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==}
     engines: {node: '>=10'}
 
-  defu@6.1.6:
-    resolution: {integrity: sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   del@8.0.1:
     resolution: {integrity: sha512-gPqh0mKTPvaUZGAuHbrBUYKZWBNAeHG7TU3QH5EhVwPMyKvmfJaNXhcD2jTcXsJRRcffuho4vaYweu80dRrMGA==}
@@ -2999,7 +2998,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@socketsecurity/lib@5.15.0(typescript@5.9.3)':
+  '@socketsecurity/lib@5.18.2(typescript@5.9.3)':
     optionalDependencies:
       typescript: 5.9.3
 
@@ -3230,7 +3229,7 @@ snapshots:
 
   decamelize@5.0.1: {}
 
-  defu@6.1.6: {}
+  defu@6.1.7: {}
 
   del@8.0.1:
     dependencies:
@@ -4045,7 +4044,7 @@ snapshots:
   unconfig@7.4.2:
     dependencies:
       '@quansync/fs': 1.0.0
-      defu: 6.1.6
+      defu: 6.1.7
       jiti: 2.6.1
       quansync: 1.0.0
       unconfig-core: 7.4.2


### PR DESCRIPTION
## Summary

- Move `@socketsecurity/lib` and `form-data` from dependencies to devDependencies — esbuild bundles them into dist, making the SDK a zero-runtime-dependency package
- Add esbuild stub plugin to replace heavy internals with minimal stubs:
  - `npm-pack.js` (2.5MB): cacache degrades gracefully (in-memory memoization works)
  - `pico-pack.js` (260KB): globs never called by SDK
  - `mime-db` (212KB): replaced with 3-entry MIME type lookup
  - `sorts.js`, `globs.js`: gateway modules to npm-pack and pico-pack
- Logger/spinner/external-pack kept for uniform look and feel (colored icons)

**dist/index.js: 3,897KB → 712KB (82% reduction), zero dependencies.**

## Test plan

- [x] All 739 tests pass
- [x] Runtime smoke test: `new SocketSdk('token')` works from bundled dist
- [x] Build succeeds with `--analyze` showing 712KB
- [ ] Verify SDK works in downstream consumers (socket-cli)