### PR TITLE
chore(release): bump to v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [4.0.1](https://github.com/SocketDev/socket-sdk-js/releases/tag/v4.0.1) - 2026-04-14
+
+### Changed — build
+
+- Bundle `@socketsecurity/lib` and `form-data` into dist output, making the SDK a zero-runtime-dependency package
+- Stub heavy `@socketsecurity/lib` internals (npm-pack.js 2.5MB, pico-pack.js 260KB) and replace `mime-db` (212KB) with a minimal 3-entry lookup
+- dist/index.js: 3,897KB → 712KB (82% reduction)
+
+### Fixed
+
+- Strip `Authorization` header (case-insensitive) from public firewall API endpoint requests
+
 ## [4.0.0](https://github.com/SocketDev/socket-sdk-js/releases/tag/v4.0.0) - 2026-04-06
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsecurity/sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "SDK for the Socket API client",
   "homepage": "https://github.com/SocketDev/socket-sdk-js",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump version to 4.0.1
- Add CHANGELOG entry for 4.0.1

### What's in 4.0.1

- **perf(build)**: Bundle `@socketsecurity/lib` and `form-data` into dist — zero runtime dependencies, dist/index.js 3,897KB → 712KB (82% reduction)
- **fix(sdk)**: Strip `Authorization` header (case-insensitive) from public firewall API endpoint requests