### PR TITLE
chore: enable eslint/curly rule

### DIFF
--- a/.git-hooks/pre-push
+++ b/.git-hooks/pre-push
@@ -168,10 +168,10 @@ while read local_ref local_sha remote_ref remote_sha; do
           ERRORS=$((ERRORS + 1))
         fi
 
-        # AWS keys.
-        if echo "$file_text" | grep -iqE '(aws_access_key|aws_secret|AKIA[0-9A-Z]{16})'; then
+        # AWS keys (word-boundary match to avoid false positives in base64 data).
+        if echo "$file_text" | grep -iqE '(aws_access_key|aws_secret|\bAKIA[0-9A-Z]{16}\b)'; then
           printf "${RED}✗ BLOCKED: Potential AWS credentials found in: %s${NC}\n" "$file"
-          echo "$file_text" | grep -niE '(aws_access_key|aws_secret|AKIA[0-9A-Z]{16})' | head -3
+          echo "$file_text" | grep -niE '(aws_access_key|aws_secret|\bAKIA[0-9A-Z]{16}\b)' | head -3
           ERRORS=$((ERRORS + 1))
         fi
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,7 +6,7 @@
     "suspicious": "error"
   },
   "rules": {
-    "eslint/curly": "off",
+    "eslint/curly": ["error", "all"],
     "eslint/no-await-in-loop": "off",
     "eslint/no-console": "off",
     "eslint/no-control-regex": "off",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "claude": "node scripts/claude.mjs",
     "security": "agentshield scan && { command -v zizmor >/dev/null && zizmor .github/ || echo 'zizmor not installed — run pnpm run setup to install'; }",
     "test": "node scripts/test.mjs",
+    "typecheck": "tsgo --noEmit",
     "type": "tsgo --noEmit -p .config/tsconfig.check.json",
     "update": "node scripts/update.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@sveltejs/acorn-typescript": "1.0.8",
     "@types/babel__traverse": "7.28.0",
     "@types/node": "24.9.2",
-    "@typescript/native-preview": "7.0.0-dev.20250926.1",
+    "@typescript/native-preview": "7.0.0-dev.20260415.1",
     "@vitest/coverage-v8": "4.0.3",
     "acorn": "8.15.0",
     "del": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "claude": "node scripts/claude.mjs",
     "security": "agentshield scan && { command -v zizmor >/dev/null && zizmor .github/ || echo 'zizmor not installed — run pnpm run setup to install'; }",
     "test": "node scripts/test.mjs",
-    "typecheck": "tsgo --noEmit",
     "type": "tsgo --noEmit -p .config/tsconfig.check.json",
     "update": "node scripts/update.mjs"
   },

--- a/src/socket-sdk-class.ts
+++ b/src/socket-sdk-class.ts
@@ -979,13 +979,17 @@ export class SocketSdk {
           urlPath,
           { ...this.#reqOptions, headers: publicHeaders },
         )
-        if (!isResponseOk(response)) return undefined
+        if (!isResponseOk(response)) {
+          return undefined
+        }
         const json = await getResponseJson(response)
         return json as unknown as SocketArtifact
       }),
     )
     for (const settled of results) {
-      if (settled.status === 'rejected' || !settled.value) continue
+      if (settled.status === 'rejected' || !settled.value) {
+        continue
+      }
       packages.push(SocketSdk.#normalizeArtifact(settled.value, publicPolicy))
     }
     return {

--- a/test/unit/coverage-non-error-paths.test.mts
+++ b/test/unit/coverage-non-error-paths.test.mts
@@ -706,7 +706,9 @@ describe('SocketSdk - checkMalware batch normalize with publicPolicy', () => {
     const result = await client.checkMalware(components)
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toHaveLength(count)
     const pkg = result.data[0]!
 
@@ -892,7 +894,9 @@ describe('SocketSdk - uploadManifestFiles edge cases', () => {
     ])
 
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.error).toBe('No readable manifest files found')
     // The cause should contain truncation for >5 files
     const cause = (result as { cause?: string }).cause ?? ''
@@ -917,7 +921,9 @@ describe('SocketSdk - uploadManifestFiles edge cases', () => {
     ])
 
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.error).toBe('Custom validation error')
     // When errorCause is not redundant with errorMessage, it should be included
     const typedResult = result as { cause?: string }
@@ -942,7 +948,9 @@ describe('SocketSdk - uploadManifestFiles edge cases', () => {
     ])
 
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.error).toBe('Custom validation error')
     // Redundant cause should be filtered out by filterRedundantCause
     const typedResult = result as { cause?: string }

--- a/test/unit/socket-sdk-check-malware.test.mts
+++ b/test/unit/socket-sdk-check-malware.test.mts
@@ -53,7 +53,9 @@ describe('SocketSdk - checkMalware', () => {
       ])
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       const pkg = result.data[0]!
       expect(pkg.alerts).toHaveLength(1)
       expect(pkg.alerts[0]!.type).toBe('malware')
@@ -95,7 +97,9 @@ describe('SocketSdk - checkMalware', () => {
       ])
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       const pkg = result.data[0]!
       expect(pkg.alerts).toHaveLength(1)
       expect(pkg.alerts[0]!.type).toBe('criticalCVE')
@@ -126,7 +130,9 @@ describe('SocketSdk - checkMalware', () => {
       ])
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       const pkg = result.data[0]!
       expect(pkg.alerts).toEqual([])
       expect(pkg.name).toBe('lodash')
@@ -154,7 +160,9 @@ describe('SocketSdk - checkMalware', () => {
       ])
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       expect(result.data[0]!.alerts).toEqual([])
     })
 
@@ -184,7 +192,9 @@ describe('SocketSdk - checkMalware', () => {
       ])
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       const pkg = result.data[0]!
       expect(pkg.namespace).toBe('@types')
       expect(pkg.name).toBe('node')
@@ -214,7 +224,9 @@ describe('SocketSdk - checkMalware', () => {
       ])
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       expect(result.data).toHaveLength(2)
       expect(result.data[0]!.alerts).toEqual([])
       expect(result.data[1]!.alerts).toHaveLength(1)
@@ -239,7 +251,9 @@ describe('SocketSdk - checkMalware', () => {
       ])
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       expect(result.data).toHaveLength(1)
       expect(result.data[0]!.name).toBe('good')
     })
@@ -254,7 +268,9 @@ describe('SocketSdk - checkMalware', () => {
       ])
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       expect(result.data).toEqual([])
     })
   })
@@ -279,7 +295,9 @@ describe('SocketSdk - checkMalware', () => {
       const result = await getClient().checkMalware(makeComponents(count))
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       expect(result.data).toHaveLength(count)
       expect(result.data[0]!.alerts).toHaveLength(1)
       expect(result.data[0]!.alerts[0]!.type).toBe('malware')
@@ -310,7 +328,9 @@ describe('SocketSdk - checkMalware', () => {
       const result = await getClient().checkMalware(makeComponents(count))
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       expect(result.data[0]!.alerts).toEqual([])
     })
 
@@ -324,7 +344,9 @@ describe('SocketSdk - checkMalware', () => {
       )
 
       expect(result.success).toBe(false)
-      if (result.success) return
+      if (result.success) {
+        return
+      }
       expect(result.status).toBe(401)
     })
 
@@ -367,7 +389,9 @@ describe('SocketSdk - checkMalware', () => {
       const result = await getClient().checkMalware(makeComponents(count))
 
       expect(result.success).toBe(true)
-      if (!result.success) return
+      if (!result.success) {
+        return
+      }
       const pkg = result.data[0]!
       expect(pkg.alerts).toHaveLength(1)
       expect(pkg.alerts[0]!.type).toBe('malware')

--- a/test/unit/socket-sdk-coverage-gaps.test.mts
+++ b/test/unit/socket-sdk-coverage-gaps.test.mts
@@ -88,7 +88,9 @@ describe('SocketSdk - batchOrgPackageFetch', () => {
     })
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toHaveLength(2)
   })
 
@@ -120,7 +122,9 @@ describe('SocketSdk - batchOrgPackageFetch', () => {
     )
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     // Only the valid artifact line should be parsed
     expect(result.data).toHaveLength(1)
   })
@@ -163,7 +167,9 @@ describe('SocketSdk - searchDependencies', () => {
     const result = await client.searchDependencies({ q: 'lodash' })
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toEqual({
       rows: [{ name: 'lodash', version: '4.17.21' }],
     })
@@ -254,7 +260,9 @@ describe('SocketSdk - File validation callbacks', () => {
       )
 
       expect(result.success).toBe(false)
-      if (result.success) return
+      if (result.success) {
+        return
+      }
       expect(result.error).toBe('Invalid files detected')
       expect(onFileValidation).toHaveBeenCalledOnce()
     })
@@ -278,7 +286,9 @@ describe('SocketSdk - File validation callbacks', () => {
       // With all files invalid and callback continuing, it falls through to
       // the "all files invalid" check and returns an error.
       expect(result.success).toBe(false)
-      if (result.success) return
+      if (result.success) {
+        return
+      }
       expect(result.error).toBe('No readable manifest files found')
     })
 
@@ -298,7 +308,9 @@ describe('SocketSdk - File validation callbacks', () => {
       )
 
       expect(result.success).toBe(false)
-      if (result.success) return
+      if (result.success) {
+        return
+      }
       expect(result.error).toBe('File validation failed')
     })
 
@@ -338,7 +350,9 @@ describe('SocketSdk - File validation callbacks', () => {
       )
 
       expect(result.success).toBe(false)
-      if (result.success) return
+      if (result.success) {
+        return
+      }
       expect(result.error).toBe('Scan file validation failed')
       expect(onFileValidation).toHaveBeenCalledOnce()
       // Verify context includes orgSlug
@@ -365,7 +379,9 @@ describe('SocketSdk - File validation callbacks', () => {
 
       // All files invalid, callback says continue, hits "all files invalid" check
       expect(result.success).toBe(false)
-      if (result.success) return
+      if (result.success) {
+        return
+      }
       expect(result.error).toBe('No readable manifest files found')
     })
 
@@ -404,7 +420,9 @@ describe('SocketSdk - File validation callbacks', () => {
       ])
 
       expect(result.success).toBe(false)
-      if (result.success) return
+      if (result.success) {
+        return
+      }
       expect(result.error).toBe('Upload validation failed')
       expect(onFileValidation).toHaveBeenCalledOnce()
       // Verify context includes orgSlug
@@ -446,7 +464,9 @@ describe('SocketSdk - File validation callbacks', () => {
       ])
 
       expect(result.success).toBe(false)
-      if (result.success) return
+      if (result.success) {
+        return
+      }
       expect(result.error).toBe('File validation failed')
     })
 
@@ -523,7 +543,9 @@ describe('SocketSdk - getApi response type handling', () => {
     >
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toBeDefined()
     expect(result.status).toBe(200)
   })
@@ -567,7 +589,9 @@ describe('SocketSdk - getApi response type handling', () => {
     })) as SocketSdkGenericResult<string>
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toBe('some text data')
     expect(result.status).toBe(200)
   })
@@ -670,7 +694,9 @@ describe('SocketSdk - sendApi additional paths', () => {
     )) as SocketSdkGenericResult<{ id: number; status: string }>
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toEqual({ id: 1, status: 'created' })
     expect(result.status).toBe(200)
   })
@@ -772,7 +798,9 @@ describe('SocketSdk - checkMalware batch path additional', () => {
     const result = await client.checkMalware(components)
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toEqual([])
   })
 
@@ -789,7 +817,9 @@ describe('SocketSdk - checkMalware batch path additional', () => {
     const result = await client.checkMalware(components)
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     // Server returns 2 artifacts for non-nonexistent purls
     expect(result.data).toHaveLength(2)
     // criticalCVE is 'warn' in publicPolicy, so it should be included
@@ -884,7 +914,9 @@ describe('SocketSdk - additional method coverage', () => {
     const result = await client.exportOpenVEX('test-org', 'vex-123')
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toBeDefined()
   })
 
@@ -897,7 +929,9 @@ describe('SocketSdk - additional method coverage', () => {
     const result = await client.rescanFullScan('test-org', 'scan-123')
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toBeDefined()
   })
 
@@ -923,7 +957,9 @@ describe('SocketSdk - additional method coverage', () => {
     })
 
     expect(result.success).toBe(true)
-    if (!result.success) return
+    if (!result.success) {
+      return
+    }
     expect(result.data).toBeDefined()
   })
 })

--- a/test/unit/socket-sdk-fail-paths.test.mts
+++ b/test/unit/socket-sdk-fail-paths.test.mts
@@ -121,7 +121,9 @@ describe('SocketSdk - #handleApiError branches', () => {
     })
     const result = await client.getQuota()
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.status).toBe(429)
     expect(result.cause).toContain('Rate limit exceeded')
     expect(result.cause).toContain('Retry after 30 seconds')
@@ -134,7 +136,9 @@ describe('SocketSdk - #handleApiError branches', () => {
     })
     const result = await client.getQuota()
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.status).toBe(429)
     expect(result.cause).toContain('Wait before retrying')
   })
@@ -147,7 +151,9 @@ describe('SocketSdk - #handleApiError branches', () => {
     })
     const result = await client.getQuota()
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.status).toBe(413)
     expect(result.cause).toContain('Payload too large')
   })
@@ -173,7 +179,9 @@ describe('SocketSdk - #handleApiError branches', () => {
     // and #handleApiError catches it.
     const result = await client.getQuota()
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.status).toBe(200)
   })
 
@@ -185,7 +193,9 @@ describe('SocketSdk - #handleApiError branches', () => {
     })
     const result = await client.getQuota()
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.status).toBe(400)
     expect(result.error).toContain('Validation failed')
     expect(result.error).toContain('field "name" is required')
@@ -199,7 +209,9 @@ describe('SocketSdk - #handleApiError branches', () => {
     })
     const result = await client.getQuota()
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.status).toBe(400)
     expect(result.error).toContain('Validation failed')
     expect(result.error).toContain('"field"')
@@ -213,7 +225,9 @@ describe('SocketSdk - #handleApiError branches', () => {
     })
     const result = await client.getQuota()
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.status).toBe(400)
     expect(result.error).toContain('Bad Request: missing parameters')
   })
@@ -527,7 +541,9 @@ describe('SocketSdk - #handleApiError statusMessage edge case', () => {
     })
     const result = await client.getQuota()
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
     expect(result.error).toContain('Unique error body text')
   })
 })

--- a/test/unit/socket-sdk-stream-limits.test.mts
+++ b/test/unit/socket-sdk-stream-limits.test.mts
@@ -77,7 +77,9 @@ describe('SocketSdk - Streaming downloads', () => {
     const chunks: Buffer[] = []
     const origWrite = process.stdout.write
     process.stdout.write = ((chunk: unknown): boolean => {
-      if (Buffer.isBuffer(chunk)) chunks.push(chunk)
+      if (Buffer.isBuffer(chunk)) {
+        chunks.push(chunk)
+      }
       return true
     }) as typeof process.stdout.write
 


### PR DESCRIPTION
Enforce braces on all control flow statements (if/else/for/while). Auto-fixed all existing violations.