### PR TITLE
fix: use named default import for @babel/traverse in generate-sdk

### DIFF
--- a/scripts/generate-sdk.mts
+++ b/scripts/generate-sdk.mts
@@ -15,7 +15,7 @@ import path from 'node:path'
 import process from 'node:process'
 
 import { parse } from '@babel/parser'
-import traverse from '@babel/traverse'
+import { default as traverse } from '@babel/traverse'
 import * as t from '@babel/types'
 import MagicString from 'magic-string'
 


### PR DESCRIPTION
## Summary

- Fix `traverse is not a function` error in `scripts/generate-sdk.mts`
- `@babel/traverse` is CJS — `import { default as traverse }` resolves correctly in both Node ESM and vite contexts

## Test plan

- [x] `pnpm run generate-sdk` succeeds