### PR TITLE
fix(ci): replace close/reopen hack with workflow_dispatch for bot PRs

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -32,6 +32,7 @@ jobs:
     name: Sync OpenAPI definition
     runs-on: ubuntu-latest
     permissions:
+      actions: write # To trigger CI workflow via workflow_dispatch
       contents: write # To push generated SDK code
       pull-requests: write # To create PRs for review
     outputs:
@@ -72,7 +73,11 @@ jobs:
       - name: Commit and push changes
         if: steps.check.outputs.has_changes == 'true'
         run: |
-          git checkout -b automated/open-api
+          # Branch from main~1 so the PR is behind main, making the
+          # "Update branch" button available to trigger enterprise checks.
+          git stash
+          git checkout -b automated/open-api HEAD~1
+          git stash pop
           git add .
           git commit -m "fix(openapi): sync with openapi definition"
           git push origin automated/open-api -fu
@@ -109,18 +114,36 @@ jobs:
           fi
 
       # Pushes made with GITHUB_TOKEN don't trigger other workflows.
-      # Close/reopen the PR to generate a pull_request.reopened event,
-      # which triggers required CI and enterprise audit workflows.
+      # Use workflow_dispatch to directly trigger CI on the PR branch.
       - name: Trigger CI checks
         if: steps.check.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+        run: gh workflow run ci.yml --ref automated/open-api
+
+      - name: Add job summary
+        if: steps.check.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          pr_number=$(gh pr list --head automated/open-api --json number --jq '.[0].number')
-          if [ -n "$pr_number" ]; then
-            gh pr close "$pr_number"
-            gh pr reopen "$pr_number"
-          fi
+          pr_number=$(gh pr list --head automated/open-api --json number --jq '.[0].number' || echo "")
+          pr_url="https://github.com/${{ github.repository }}/pull/${pr_number}"
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## OpenAPI Sync Complete
+
+          **PR:** [#${pr_number}](${pr_url})
+
+          > **Note:** Enterprise required workflows (e.g. Audit GHA Workflows) won't trigger
+          > automatically on bot PRs. Click **"Update branch"** on the PR to trigger them,
+          > or push an empty commit to the branch:
+          >
+          > \`\`\`sh
+          > git fetch origin automated/open-api && git checkout automated/open-api
+          > git commit --allow-empty -m "chore: trigger enterprise checks"
+          > git push origin automated/open-api
+          > \`\`\`
+          EOF
 
       - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
         if: always()

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -45,6 +45,7 @@ jobs:
     if: needs.check-updates.outputs.has-updates == 'true' && inputs.dry-run != true
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -57,7 +58,9 @@ jobs:
         run: |
           BRANCH_NAME="weekly-update-$(date +%Y%m%d)"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-          git checkout -b "$BRANCH_NAME"
+          # Branch from HEAD~1 so the PR is behind main, making the
+          # "Update branch" button available to trigger enterprise checks.
+          git checkout -b "$BRANCH_NAME" HEAD~1
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
       - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
@@ -269,30 +272,41 @@ jobs:
             --base main
 
       # Pushes made with GITHUB_TOKEN don't trigger other workflows.
-      # Close/reopen the PR to generate a pull_request.reopened event,
-      # which triggers required CI and enterprise audit workflows.
+      # Use workflow_dispatch to directly trigger CI on the PR branch.
       - name: Trigger CI checks
         if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
-        run: |
-          pr_number=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number')
-          if [ -n "$pr_number" ]; then
-            gh pr close "$pr_number"
-            gh pr reopen "$pr_number"
-          fi
+        run: gh workflow run ci.yml --ref "$BRANCH_NAME"
 
       - name: Add job summary
         if: steps.final.outputs.success == 'true' && steps.validate.outputs.valid == 'true' && steps.changes.outputs.has-changes == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ steps.branch.outputs.branch }}
         run: |
           COMMIT_COUNT=$(git rev-list --count origin/main..HEAD)
-          echo "## Weekly Update Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${BRANCH_NAME}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Commits:** ${COMMIT_COUNT}" >> $GITHUB_STEP_SUMMARY
+          pr_number=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' || echo "")
+          pr_url="https://github.com/${{ github.repository }}/pull/${pr_number}"
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Weekly Update Complete
+
+          **PR:** [#${pr_number}](${pr_url})
+          **Branch:** \`${BRANCH_NAME}\`
+          **Commits:** ${COMMIT_COUNT}
+
+          > **Note:** Enterprise required workflows (e.g. Audit GHA Workflows) won't trigger
+          > automatically on bot PRs. Click **"Update branch"** on the PR to trigger them,
+          > or push an empty commit to the branch:
+          >
+          > \`\`\`sh
+          > git fetch origin ${BRANCH_NAME} && git checkout ${BRANCH_NAME}
+          > git commit --allow-empty -m "chore: trigger enterprise checks"
+          > git push origin ${BRANCH_NAME}
+          > \`\`\`
+          EOF
 
       - name: Upload Claude output
         if: always()


### PR DESCRIPTION
## Summary

- Replace the `gh pr close` / `gh pr reopen` workaround with `gh workflow run ci.yml --ref <branch>` in both `generate.yml` and `weekly-update.yml`
- Add `actions: write` permission to both jobs to allow dispatching workflows
- Add job summaries with instructions to click **"Update branch"** on the PR to trigger enterprise required workflows (e.g. Audit GHA Workflows)

The close/reopen hack never worked — `GITHUB_TOKEN` suppresses all events it creates, including `pull_request.reopened`. `workflow_dispatch` is exempt from this suppression, so CI now actually triggers. Enterprise org-level workflows still require a real user event, hence the "Update branch" instructions as a stopgap.

## Test plan

- [ ] Verify `generate.yml` workflow dispatches CI on `automated/open-api` branch
- [ ] Verify `weekly-update.yml` workflow dispatches CI on update branch
- [ ] Verify job summaries render with PR link and instructions
- [ ] Confirm no more close/reopen noise on bot PRs