### PR TITLE
chore(tsconfig): explicit sourceMap and declarationMap: false

### DIFF
--- a/.claude/hooks/check-new-deps/tsconfig.json
+++ b/.claude/hooks/check-new-deps/tsconfig.json
@@ -1,13 +1,15 @@
 {
   "compilerOptions": {
-    "noEmit": true,
-    "target": "esnext",
+    "declarationMap": false,
+    "erasableSyntaxOnly": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "noEmit": true,
     "rewriteRelativeImportExtensions": true,
-    "erasableSyntaxOnly": true,
-    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "sourceMap": false,
     "strict": true,
-    "skipLibCheck": true
+    "target": "esnext",
+    "verbatimModuleSyntax": true
   }
 }

--- a/.config/tsconfig.check.json
+++ b/.config/tsconfig.check.json
@@ -1,10 +1,12 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "declarationMap": false,
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,
     "skipLibCheck": true,
+    "sourceMap": false,
     "types": ["vitest/globals", "node"],
     "verbatimModuleSyntax": false
   },

--- a/.config/tsconfig.check.local.json
+++ b/.config/tsconfig.check.local.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.check.json",
   "compilerOptions": {
+    "declarationMap": false,
     "paths": {
       "@socketsecurity/lib": ["../../socket-lib/dist/index.d.ts"],
       "@socketsecurity/lib/*": ["../../socket-lib/dist/*"],
@@ -8,6 +9,7 @@
         "../../socket-registry/registry/dist/index.d.ts"
       ],
       "@socketsecurity/registry/*": ["../../socket-registry/registry/dist/*"]
-    }
+    },
+    "sourceMap": false
   }
 }

--- a/.config/tsconfig.dts.json
+++ b/.config/tsconfig.dts.json
@@ -6,10 +6,11 @@
     "emitDeclarationOnly": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "noPropertyAccessFromIndexSignature": false,
     "outDir": "../dist",
     "rootDir": "../src",
-    "noPropertyAccessFromIndexSignature": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "sourceMap": false
   },
   "include": ["../src/**/*.ts", "../types/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,14 @@
 {
   "extends": "./.config/tsconfig.base.json",
   "compilerOptions": {
+    "declarationMap": false,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "noEmit": true,
+    "noPropertyAccessFromIndexSignature": false,
     "outDir": "./dist",
     "rootDir": "./src",
-    "noPropertyAccessFromIndexSignature": false,
-    "noEmit": true
+    "sourceMap": false
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Sets `sourceMap: false` and `declarationMap: false` explicitly on every `tsconfig.json` in the repo. Keys are fully alphanumerically sorted within each `compilerOptions` block.

We never want to ship sourcemaps or declaration maps. Making the flags explicit prevents accidental regression when someone edits a config and forgets to check inheritance.

## Files touched

- `.config/tsconfig.check.json`
- `.config/tsconfig.check.local.json`
- `.config/tsconfig.dts.json` (adds `sourceMap: false`)
- `tsconfig.json`
- `.claude/hooks/check-new-deps/tsconfig.json`

Paired with the same change in [socket-cli#1213](https://github.com/SocketDev/socket-cli/pull/1213).