### PR TITLE
docs(claude): always existsSync for file existence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 - Backward Compatibility: 🚨 FORBIDDEN to maintain - actively remove when encountered (see canonical CLAUDE.md)
 - 🚨 **NEVER use `npx`, `pnpm dlx`, or `yarn dlx`** — use `pnpm exec <package>` for devDep binaries, or `pnpm run <script>` for package.json scripts. If a tool is needed, add it as a pinned devDependency first.
 - **minimumReleaseAge**: NEVER add packages to `minimumReleaseAgeExclude` in CI. Locally, ASK before adding — the age threshold is a security control.
+- File existence: ALWAYS `existsSync` from `node:fs`. NEVER `fs.access`, `fs.stat`-for-existence, or an async `fileExists` wrapper. Import form: `import { existsSync, promises as fs } from 'node:fs'`.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add a shared-standards rule: use `existsSync` from `node:fs` for file-existence checks.
- Forbid `fs.access`, `fs.stat`-for-existence, and async `fileExists` wrappers.
- Canonical import form: `import { existsSync, promises as fs } from 'node:fs'`.

Docs-only; no code changes. Keeps socket-sdk-js's CLAUDE.md in sync with the shared rule being rolled out across the socket-* repos.

## Test plan

- [x] `pnpm run fix` + `pnpm run check` passed via pre-commit hooks
- [ ] Reviewer sanity-check the wording