### PR TITLE
fix(test): pass --passWithNoTests to vitest

### DIFF
--- a/scripts/test.mts
+++ b/scripts/test.mts
@@ -236,7 +236,16 @@ async function runTests(
   const vitestCmd = WIN32 ? 'vitest.cmd' : 'vitest'
   const vitestPath = path.join(nodeModulesBinPath, vitestCmd)
 
-  const vitestArgs = ['--config', '.config/vitest.config.mts', 'run']
+  // --passWithNoTests: a scoped run where the changed files don't resolve
+  // to any test file should succeed rather than error with "No test files
+  // found". Keeps pre-commit hooks passing when an edit touches only
+  // non-testable code.
+  const vitestArgs = [
+    '--config',
+    '.config/vitest.config.mts',
+    'run',
+    '--passWithNoTests',
+  ]
 
   // Add coverage if requested
   if (coverage) {

--- a/scripts/test.mts
+++ b/scripts/test.mts
@@ -236,16 +236,19 @@ async function runTests(
   const vitestCmd = WIN32 ? 'vitest.cmd' : 'vitest'
   const vitestPath = path.join(nodeModulesBinPath, vitestCmd)
 
-  // --passWithNoTests: a scoped run where the changed files don't resolve
-  // to any test file should succeed rather than error with "No test files
-  // found". Keeps pre-commit hooks passing when an edit touches only
-  // non-testable code.
-  const vitestArgs = [
-    '--config',
-    '.config/vitest.config.mts',
-    'run',
-    '--passWithNoTests',
-  ]
+  const vitestArgs = ['--config', '.config/vitest.config.mts', 'run']
+
+  // --passWithNoTests is only safe for scoped runs (specific test files from
+  // the changed-file mapper, or user-supplied positional patterns). In those
+  // cases, "no matching test file" is an expected non-failure — e.g., an edit
+  // touches only non-testable code, or the user points vitest at a file
+  // outside the test globs. For --all/--force runs (and the fallback where
+  // the mapper returns 'all'), an empty test run is a real signal (e.g.,
+  // wholesale test deletion, broken globs) and must surface as failure.
+  const isScopedRun = testsToRun !== 'all' || positionals.length > 0
+  if (isScopedRun) {
+    vitestArgs.push('--passWithNoTests')
+  }
 
   // Add coverage if requested
   if (coverage) {


### PR DESCRIPTION
## Summary

- When a scoped test run (pre-commit hook with `--staged`, or any partial scope) only touches files that don't map to any test file, `vitest` exits with code 1 and "No test files found".
- That's a false failure — a scope that happens to produce zero matches should succeed, not block a commit.
- Add `--passWithNoTests` to the vitest args so the exit code reflects actual test outcomes.

## Test plan

- [ ] `pnpm test` on a change that only touches non-test files (e.g. a README edit) no longer errors
- [ ] `pnpm test` that does touch tests still runs and fails/passes correctly
- [ ] Pre-commit hook passes on commits that don't affect tests