### PR TITLE
perf(build): expand lib stub pattern to cover unused transitive externals

### DIFF
--- a/.config/esbuild.config.mts
+++ b/.config/esbuild.config.mts
@@ -241,8 +241,21 @@ function createNodeProtocolPlugin() {
  *     minimal lookup covering just those types.
  */
 function createLibStubPlugin() {
+  // Heavy lib modules that are eagerly required but never exercised
+  // by the SDK's actual code paths.
+  //
+  // Never-reached by SDK gateway modules:
+  //   - globs.js / sorts.js → only used by fs helpers the SDK skips
+  //   - external/npm-pack.js / pico-pack.js → Arborist/pacote/fast-glob,
+  //     SDK only needs validateFiles() from fs
+  //
+  // Never-reached transitive external shims:
+  //   - external/cacache.js → destructures from npm-pack (already stubbed),
+  //     SDK's cache-with-ttl path degrades gracefully
+  //   - external/del.js → pulled in by fs's lazy getDel() for safeDelete,
+  //     SDK never calls safeDelete/safeDeleteSync
   const libStubPattern =
-    /@socketsecurity\/lib\/dist\/(globs|sorts|external\/(npm-pack|pico-pack))\.js$/
+    /@socketsecurity\/lib\/dist\/(globs|sorts|external\/(npm-pack|pico-pack|cacache|del))\.js$/
 
   const mimeDbPattern = /mime-db\/db\.json$/
 


### PR DESCRIPTION
## Summary

- Expand `createLibStubPlugin` in `.config/esbuild.config.mts` to additionally stub `@socketsecurity/lib/dist/external/del.js` and `@socketsecurity/lib/dist/external/cacache.js`
- These two shims are eagerly loaded by `@socketsecurity/lib/dist/fs.js` (via lazy `getDel()`) and by `@socketsecurity/lib/dist/cacache.js` (destructures from already-stubbed `npm-pack`), but the SDK never calls `safeDelete`/`safeDeleteSync` and its `cache-with-ttl` path degrades gracefully

## Result

`dist/index.js`: 712,442 → 711,934 bytes (−508 bytes)

Modest on its own; the larger win flows from upstream socket-lib 5.19.0, which adds ~14 new stubs (sigstore/tuf/arborist internals) that cascade into the SDK's bundle automatically on the next lib bump.

## Test plan

- [x] `pnpm run build` succeeds, emits type declarations
- [x] `pnpm exec vitest run` shows same pass/fail counts as `main` (739 passing; 1 pre-existing `.claude/hooks/check-new-deps` failure unrelated to this change)
- [ ] CI green