### PR TITLE
fix: eliminate Promise.race handler-stacking in batchPackageStream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@
 - 🚨 **NEVER use `npx`, `pnpm dlx`, or `yarn dlx`** — use `pnpm exec <package>` for devDep binaries, or `pnpm run <script>` for package.json scripts. If a tool is needed, add it as a pinned devDependency first.
 - **minimumReleaseAge**: NEVER add packages to `minimumReleaseAgeExclude` in CI. Locally, ASK before adding — the age threshold is a security control.
 - File existence: ALWAYS `existsSync` from `node:fs`. NEVER `fs.access`, `fs.stat`-for-existence, or an async `fileExists` wrapper. Import form: `import { existsSync, promises as fs } from 'node:fs'`.
+- `Promise.race` / `Promise.any`: NEVER pass a long-lived promise (interrupt signal, pool member) into a race inside a loop. Each call re-attaches `.then` handlers to every arm; handlers accumulate on surviving promises until they settle. For concurrency limiters, use a single-waiter "slot available" signal (resolved by each task's `.then`) instead of re-racing `executing[]`. See nodejs/node#17469 and `@watchable/unpromise`. Race with two fresh arms (e.g. one-shot `withTimeout`) is safe.
 
 ---
 
@@ -162,6 +163,7 @@ All `logger.error()` and `logger.log()` calls include empty string:
 - **Type safety**: ❌ FORBIDDEN `any`; use `unknown` or specific
 - **Type imports**: Always `import type`
 - **Nullish values**: Prefer `undefined` over `null` - use `undefined` for absent/missing values
+- **Promise.race in loops**: ❌ NEVER re-race the same pool across iterations. Each race attaches fresh `.then` handlers to every arm; long-surviving promises accumulate handler sets ([nodejs/node#17469](https://github.com/nodejs/node/issues/17469)). Fresh-both-arms races (timeout wrappers) are fine. For concurrency limiters like `batchPackageStream`, use a single-waiter queue — each in-flight task's own `.then` delivers into a buffer, the loop awaits a one-shot `promiseWithResolvers` and replaces it per iteration.
 
 #### HTTP Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,6 @@ All `logger.error()` and `logger.log()` calls include empty string:
 - **Type safety**: ❌ FORBIDDEN `any`; use `unknown` or specific
 - **Type imports**: Always `import type`
 - **Nullish values**: Prefer `undefined` over `null` - use `undefined` for absent/missing values
-- **Promise.race in loops**: ❌ NEVER re-race the same pool across iterations. Each race attaches fresh `.then` handlers to every arm; long-surviving promises accumulate handler sets ([nodejs/node#17469](https://github.com/nodejs/node/issues/17469)). Fresh-both-arms races (timeout wrappers) are fine. For concurrency limiters like `batchPackageStream`, use a single-waiter queue — each in-flight task's own `.then` delivers into a buffer, the loop awaits a one-shot `promiseWithResolvers` and replaces it per iteration.
 
 #### HTTP Requests
 

--- a/src/socket-sdk-class.ts
+++ b/src/socket-sdk-class.ts
@@ -867,10 +867,50 @@ export class SocketSdk {
     /* c8 ignore stop */
     const { components } = componentsObj
     const { length: componentsCount } = components
-    const running = new Map<
-      AsyncGenerator<BatchPackageFetchResultType>,
-      Promise<GeneratorStep>
-    >()
+    // Tracks in-flight generators only for pool-size accounting.
+    // Completed steps and errors flow through the single-waiter queue below,
+    // not through per-generator promises re-raced each iteration — repeated
+    // Promise.race() over the same pool accumulates unreleased .then
+    // handlers on each still-pending arm until the pool drains.
+    // See https://github.com/nodejs/node/issues/17469.
+    const running = new Set<AsyncGenerator<BatchPackageFetchResultType>>()
+    const completed: GeneratorStep[] = []
+    let waiter: {
+      resolve: (step: GeneratorStep) => void
+      reject: (err: unknown) => void
+    } | null = null
+    let pendingError: { err: unknown } | null = null
+    const deliverStep = (step: GeneratorStep) => {
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w.resolve(step)
+      } else {
+        completed.push(step)
+      }
+    }
+    const deliverError = (err: unknown) => {
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w.reject(err)
+      } else if (!pendingError) {
+        pendingError = { err }
+      }
+    }
+    const takeStep = (): Promise<GeneratorStep> => {
+      if (pendingError) {
+        const { err } = pendingError
+        pendingError = null
+        return Promise.reject(err)
+      }
+      if (completed.length) {
+        return Promise.resolve(completed.shift()!)
+      }
+      const { promise, resolve, reject } = promiseWithResolvers<GeneratorStep>()
+      waiter = { resolve, reject }
+      return promise
+    }
     let index = 0
     const enqueueGen = () => {
       if (index >= componentsCount) {
@@ -888,17 +928,12 @@ export class SocketSdk {
     const continueGen = (
       generator: AsyncGenerator<BatchPackageFetchResultType>,
     ) => {
-      const {
-        promise,
-        reject: rejectFn,
-        resolve: resolveFn,
-      } = promiseWithResolvers<GeneratorStep>()
-      running.set(generator, promise)
+      running.add(generator)
       void generator
         .next()
         .then(
-          iteratorResult => resolveFn({ generator, iteratorResult }),
-          rejectFn,
+          iteratorResult => deliverStep({ generator, iteratorResult }),
+          deliverError,
         )
     }
     // Start initial batch of generators.
@@ -907,9 +942,7 @@ export class SocketSdk {
     }
     while (running.size > 0) {
       // eslint-disable-next-line no-await-in-loop
-      const { generator, iteratorResult }: GeneratorStep = await Promise.race(
-        running.values(),
-      )
+      const { generator, iteratorResult }: GeneratorStep = await takeStep()
       running.delete(generator)
       // Yield the value if one is given, even when done:true.
       if (iteratorResult.value) {

--- a/src/socket-sdk-class.ts
+++ b/src/socket-sdk-class.ts
@@ -875,15 +875,17 @@ export class SocketSdk {
     // See https://github.com/nodejs/node/issues/17469.
     const running = new Set<AsyncGenerator<BatchPackageFetchResultType>>()
     const completed: GeneratorStep[] = []
-    let waiter: {
-      resolve: (step: GeneratorStep) => void
-      reject: (err: unknown) => void
-    } | null = null
-    let pendingError: { err: unknown } | null = null
+    let waiter:
+      | {
+          reject: (err: unknown) => void
+          resolve: (step: GeneratorStep) => void
+        }
+      | undefined
+    let pendingError: { err: unknown } | undefined
     const deliverStep = (step: GeneratorStep) => {
       if (waiter) {
         const w = waiter
-        waiter = null
+        waiter = undefined
         w.resolve(step)
       } else {
         completed.push(step)
@@ -892,7 +894,7 @@ export class SocketSdk {
     const deliverError = (err: unknown) => {
       if (waiter) {
         const w = waiter
-        waiter = null
+        waiter = undefined
         w.reject(err)
       } else if (!pendingError) {
         pendingError = { err }
@@ -901,14 +903,14 @@ export class SocketSdk {
     const takeStep = (): Promise<GeneratorStep> => {
       if (pendingError) {
         const { err } = pendingError
-        pendingError = null
+        pendingError = undefined
         return Promise.reject(err)
       }
       if (completed.length) {
         return Promise.resolve(completed.shift()!)
       }
-      const { promise, resolve, reject } = promiseWithResolvers<GeneratorStep>()
-      waiter = { resolve, reject }
+      const { promise, reject, resolve } = promiseWithResolvers<GeneratorStep>()
+      waiter = { reject, resolve }
       return promise
     }
     let index = 0


### PR DESCRIPTION
## Summary

- **Fix** (`src/socket-sdk-class.ts`): `batchPackageStream` re-raced a persistent pool of generator promises each iteration. Every `Promise.race(running.values())` call attached a fresh `.then(resolve, reject)` pair to *every* still-pending arm, so long-running generators accumulated `O(iterations_survived)` dead handler closures before finally settling. See [nodejs/node#17469](https://github.com/nodejs/node/issues/17469) and [@watchable/unpromise](https://github.com/cefn/watchable/tree/main/packages/unpromise) for the pattern.
- Replaced with a single-waiter queue: each generator's own `.then` delivers its step into a buffer, and the main loop awaits a fresh `promiseWithResolvers` each iteration. Handlers are one-shot — nothing to stack. Rejection and ordering semantics preserved.
- **Docs** (`CLAUDE.md`): added a concise rule under SHARED STANDARDS so the pattern is not reintroduced.

## Test plan

- [x] All 565 existing tests pass (`pnpm test`)
- [x] `pnpm run check` (lint + type-check) clean
- [x] Verified via standalone sanity script: result ordering preserved, rejection propagation preserved