### PR TITLE
fix(lint): correct glob-to-regex translation for oxlint excludes

### DIFF
--- a/scripts/lint.mts
+++ b/scripts/lint.mts
@@ -59,20 +59,25 @@ function getOxlintExcludePatterns(): string[] {
 
 /**
  * Check if a file matches any of the exclude patterns.
+ *
+ * Handles directory patterns (`**\/dist` → matches `dist` and any file inside
+ * it) and file-glob patterns (`**\/*.d.ts` → matches any `.d.ts` file). The
+ * substitution order is deliberate: regex metacharacters in the literal
+ * pattern are escaped first, then `**\/` and `*` are translated in a single
+ * pass via a callback so later substitutions can't corrupt earlier ones.
  */
 function isExcludedByOxlint(file: string, excludePatterns: string[]): boolean {
   for (const pattern of excludePatterns) {
-    // Convert glob pattern to regex-like matching
-    // Support **/ for directory wildcards and * for filename wildcards
+    // Escape regex metacharacters in the literal pattern (dots etc.), then
+    // translate glob tokens in a single pass.
     const regexPattern = pattern
-      // **/ matches any directory
-      .replace(/\*\*\//g, '.*')
-      // * matches any characters except /
-      .replace(/\*/g, '[^/]*')
-      // Escape dots
-      .replace(/\./g, '\\.')
+      .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*\*\/|\*/g, m => (m === '*' ? '[^/]*' : '(?:.*/)?'))
 
-    const regex = new RegExp(`^${regexPattern}$`)
+    // Match the pattern as an exact path OR as a directory prefix (pattern
+    // followed by `/`). This makes `**/dist` exclude both `dist` itself and
+    // every descendant.
+    const regex = new RegExp(`^${regexPattern}(?:/|$)`)
     if (regex.test(file)) {
       return true
     }


### PR DESCRIPTION
## Summary

`isExcludedByOxlint` in `scripts/lint.mts` had two defects that caused the lint runner to exit non-zero whenever the only changed files were inside an oxlint-excluded directory like `.claude/`. Symptom: `pnpm run check` (and the pre-commit hook) emits `Linting failed / Expected at least one target file`.

## The bugs

1. **Replacement order corrupted the regex.** The old code did `**/ → .*`, then `* → [^/]*`, then `. → \.`. The last step escaped the dots in the just-introduced `.*` and `[^/]*` patterns; and the `*` replacement also consumed the `*` in the `.*` produced by the `**/` step. `**/.claude` ended up as `\.[^/]*\.claude` — wrong.
2. **Exact-match anchoring.** Even after fixing (1), the regex used `$` at the end so `**/dist` only matched the bare path `dist`, never files *inside* like `dist/foo.js`.

## The fix

- Escape regex metacharacters on the original pattern first.
- Translate `**/` and `*` in a single callback-based pass so later substitutions can't corrupt earlier ones.
- Anchor with `(?:/|$)` so directory patterns also match descendants.

## Test plan

- [x] `pnpm run check` passes on this branch
- [x] 21-case harness against all 13 patterns in `.oxlintrc.json` — directories (`**/dist`), descendants (`dist/foo.js`), nested patterns (`**/test/fixtures`), file globs (`**/*.d.ts`, `**/*.tsbuildinfo`), lookalike siblings that must NOT match (`coverage-other` vs `**/coverage`, `distributed` vs `**/dist`, `.cachewhatever` vs `**/.cache`), and deep paths (`a/b/tsconfig.tsbuildinfo`)
- [ ] Confirm `pnpm run check` on a future PR that only touches `.claude/` files no longer reports spurious lint failure