### PR TITLE
docs(claude): perfectionist default + bump pnpm to 11.0.0-rc.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,12 @@ Also available: `setupTestEnvironment()` (nock only), `createTestClient()` (clie
 - If you spot a bug adjacent to what was asked, flag it: "I also noticed X — want me to fix it?"
 - You are a collaborator, not just an executor
 - When a warning (lint, type-check, build, runtime) surfaces in code you're already editing, fix it in the same change — don't leave it for later. For warnings in unrelated files, flag them instead of drive-by fixing.
+- **Default to perfectionist mindset**: when you have latitude to choose, pick the maximally correct option — no shortcuts, no cosmetic deferrals. Fix state that _looks_ stale even if not load-bearing. If pragmatism is the right call, the user will ask for it explicitly. "Works now" ≠ "right."
+
+### Self-Evaluation
+
+- Before calling done: present two views — perfectionist reject vs. pragmatist ship — and let the user decide. If the user gives no signal, default to perfectionist: do the fuller fix.
+- If a fix fails twice: stop, re-read top-down, state where the mental model was wrong, try something fundamentally different
 
 ### Completion Protocol
 

--- a/package.json
+++ b/package.json
@@ -111,5 +111,5 @@
     "node": ">=18.20.8",
     "pnpm": ">=11.0.0-rc.0"
   },
-  "packageManager": "pnpm@11.0.0-rc.2"
+  "packageManager": "pnpm@11.0.0-rc.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,178 +5,45 @@ importers:
 
   .:
     configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 11.0.0-rc.2
-        version: 11.0.0-rc.2
-      pnpm:
-        specifier: 11.0.0-rc.2
-        version: 11.0.0-rc.2
+    packageManagerDependencies: {}
 
 packages:
 
-  '@pnpm/exe@11.0.0-rc.2':
-    resolution: {integrity: sha512-EkL8nZApA0wUA7c5hDdbeuyNUkmkDRBn8evxx4O79SMlEX1D6XspEu9EkLmT+sqrHsAwKzHTHsNYwTSOuKavRg==}
-    hasBin: true
 
-  '@pnpm/linux-arm64@11.0.0-rc.2':
-    resolution: {integrity: sha512-aw7wUq6ffXAfP7r9ZKa7GQmCoh/2EJcdb5ghkc8cgz0O2RZCmIaHqMV2O049iSAtblANkOu5uhwAZW7DKMJa3A==}
-    cpu: [arm64]
-    os: [linux]
 
-  '@pnpm/linux-x64@11.0.0-rc.2':
-    resolution: {integrity: sha512-aCItGORv4lUjYldScyhd7uxgXQI3s1B1s99u5Eb42KRRC4Q8DAf7dboXbLGk7rQLjx8F9xIiaD7QX7YR8+MWEQ==}
-    cpu: [x64]
-    os: [linux]
 
-  '@pnpm/macos-arm64@11.0.0-rc.2':
-    resolution: {integrity: sha512-WsLK8St9Hpwp26qqdFVdLdDlJ3CLJVIkcFwP7G9b+HtkPZOx+Z9AGZ8iam1B7HSrf8XomZWlq0vntHDsc2uPTg==}
-    cpu: [arm64]
-    os: [darwin]
 
-  '@pnpm/macos-x64@11.0.0-rc.2':
-    resolution: {integrity: sha512-hiC0khjWqSu6l25rs52izVhPM+6IVbp89pLRyBMYTe5x2a9iydUsCloPl7E+SuNiZ5cNnG28qj3PDzc5upeH/Q==}
-    cpu: [x64]
-    os: [darwin]
 
-  '@pnpm/win-arm64@11.0.0-rc.2':
-    resolution: {integrity: sha512-+bo8RmPQyPCKq+h1GE/QHJ7Ybt/4bWZLUSgXJQS6UOB7ar56g2g4ii1X5+8htkkdXxS5Uoj2TVqRjKp6hkkAdA==}
-    cpu: [arm64]
-    os: [win32]
 
-  '@pnpm/win-x64@11.0.0-rc.2':
-    resolution: {integrity: sha512-srkbMALQgb4taTzKMlwqBZV+JHTh15jN4/FOVOGQ5XadjXdpJOievkvp/m87WankP8MX8th+mJhD9RX/rDOSOw==}
-    cpu: [x64]
-    os: [win32]
 
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
 
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
 
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
 
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
 
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
 
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
 
-  pnpm@11.0.0-rc.2:
-    resolution: {integrity: sha512-JkEMwm1mi63d4ToKzyx1ytALgqR3vMHi/mKd1B1reP4/stm7Ujr/951qkfBr6bkKYDJUPzC19zkxI5yCCqXwAQ==}
-    engines: {node: '>=22.13'}
-    hasBin: true
 
 snapshots:
 
-  '@pnpm/exe@11.0.0-rc.2':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.0.0-rc.2
-      '@pnpm/linux-x64': 11.0.0-rc.2
-      '@pnpm/macos-arm64': 11.0.0-rc.2
-      '@pnpm/macos-x64': 11.0.0-rc.2
-      '@pnpm/win-arm64': 11.0.0-rc.2
-      '@pnpm/win-x64': 11.0.0-rc.2
 
-  '@pnpm/linux-arm64@11.0.0-rc.2':
-    optional: true
 
-  '@pnpm/linux-x64@11.0.0-rc.2':
-    optional: true
 
-  '@pnpm/macos-arm64@11.0.0-rc.2':
-    optional: true
 
-  '@pnpm/macos-x64@11.0.0-rc.2':
-    optional: true
 
-  '@pnpm/win-arm64@11.0.0-rc.2':
-    optional: true
 
-  '@pnpm/win-x64@11.0.0-rc.2':
-    optional: true
 
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
 
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
 
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
 
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
 
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
 
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
 
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
 
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
 
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
 
-  pnpm@11.0.0-rc.2: {}
 
 ---
 lockfileVersion: '9.0'


### PR DESCRIPTION
## Summary

Two commits:

1. **`docs(claude)`: default to perfectionist mindset when user is silent** — adds \`Default to perfectionist mindset\` to \`### Judgment Protocol\` and a new \`### Self-Evaluation\` section that defaults to perfectionist when the user gives no signal between the two views. Rolled out consistently across the Socket fleet.

2. **`chore(deps)`: bump pnpm to 11.0.0-rc.3 + drop stale packageManagerDependencies** — bumps \`packageManager\` in \`package.json\` to \`pnpm@11.0.0-rc.3\` and strips the stale \`packageManagerDependencies\` block (plus orphaned \`@pnpm/exe*\`, \`@pnpm/*\`, \`@reflink/*\`, \`pnpm@\` entries) from the lockfile. The CI setup action downloads the pnpm tarball directly onto PATH, so the lockfile bootstrap block is unnecessary — and rc.2/rc.3 \`@pnpm/exe\` ships a stub pnpm binary that dies with \`This: not found\` when pnpm's \`strictDepBuilds\` default blocks the preinstall that links the real binary.

## Test plan

- [x] \`pnpm install --frozen-lockfile\` succeeds
- [x] \`pnpm run fix --all\` clean
- [x] \`pnpm run check --all\` passes (lint + check)
- [x] \`pnpm run test\` passes
- [ ] CI green on all platforms (Linux/macOS/Windows)