### PR TITLE
chore(ci): bump socket-registry workflow refs to 594526f (pnpm rc.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@594526f395d117daaf2e2e228211054d763b3083 # main
     with:
       test-script: 'pnpm run test --all --skip-build'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -46,14 +46,14 @@ jobs:
           echo "Sleeping for $delay seconds..."
           sleep $delay
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@594526f395d117daaf2e2e228211054d763b3083 # main
 
       - name: Configure push credentials
         env:
           GH_TOKEN: ${{ github.token }}
         run: git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@594526f395d117daaf2e2e228211054d763b3083 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -145,5 +145,5 @@ jobs:
           > \`\`\`
           EOF
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@594526f395d117daaf2e2e228211054d763b3083 # main
         if: always()

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write # To create GitHub releases
       id-token: write # For npm trusted publishing via OIDC
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@594526f395d117daaf2e2e228211054d763b3083 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       has-updates: ${{ steps.check.outputs.has-updates }}
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@594526f395d117daaf2e2e228211054d763b3083 # main
 
       - name: Check for npm updates
         id: check
@@ -49,7 +49,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@594526f395d117daaf2e2e228211054d763b3083 # main
 
       - name: Create update branch
         id: branch
@@ -63,7 +63,7 @@ jobs:
           git checkout -b "$BRANCH_NAME" HEAD~1
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@594526f395d117daaf2e2e228211054d763b3083 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -320,7 +320,7 @@ jobs:
             test-output.log
           retention-days: 7
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@bbe46386c0a2bc6baefd02916234956a38e622d5 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@594526f395d117daaf2e2e228211054d763b3083 # main
         if: always()
 
   notify:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ loglevel: error
 trustPolicy: no-downgrade
 
 allowBuilds:
+  '@pnpm/exe': true
   esbuild: true
 
 overrides:


### PR DESCRIPTION
Bumps socket-registry workflow SHA pins to `594526f` (the Layer 3 merge that ships pnpm 11.0.0-rc.3 across ci/provenance/weekly-update).