### PR TITLE
chore(config): drop resolutionMode: highest

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
-resolutionMode: highest
 loglevel: error
 trustPolicy: no-downgrade
 


### PR DESCRIPTION
## Summary

- Remove \`resolutionMode: highest\` from \`pnpm-workspace.yaml\`.
- Was added specifically to work around pnpm v11 \`ERR_PNPM_MISSING_TIME\` (upstream: pnpm/pnpm#11238).
- Fixed upstream in pnpm 11.0.0-rc.2 by #11293, which introduced \`minimumReleaseAgeIgnoreMissingTime\` (default \`true\`) — pnpm now emits a warn-once instead of throwing when registry metadata lacks the \`time\` field.
- We pin ≥ rc.2, so v11's default \`time-based\` resolution works again.

## Test plan

- [ ] CI green on this branch