### PR TITLE
chore(fleet): adopt pnpm 11.0.0-rc.5 and bump socket-registry pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@d638c11f4bc7ac637e0f61f05729a54d68af40e0 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
     with:
       test-script: 'pnpm run test --all --skip-build'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -46,14 +46,14 @@ jobs:
           echo "Sleeping for $delay seconds..."
           sleep $delay
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@d638c11f4bc7ac637e0f61f05729a54d68af40e0 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
 
       - name: Configure push credentials
         env:
           GH_TOKEN: ${{ github.token }}
         run: git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@d638c11f4bc7ac637e0f61f05729a54d68af40e0 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -145,5 +145,5 @@ jobs:
           > \`\`\`
           EOF
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@d638c11f4bc7ac637e0f61f05729a54d68af40e0 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
         if: always()

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write # To create GitHub releases
       id-token: write # For npm trusted publishing via OIDC
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@d638c11f4bc7ac637e0f61f05729a54d68af40e0 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   weekly-update:
-    uses: SocketDev/socket-registry/.github/workflows/weekly-update.yml@d638c11f4bc7ac637e0f61f05729a54d68af40e0 # main
+    uses: SocketDev/socket-registry/.github/workflows/weekly-update.yml@ebf1b48f962ea4978d63f18d5ac711cab94d597f # main
     with:
       test-setup-script: 'pnpm run build'
       test-script: 'pnpm test'

--- a/package.json
+++ b/package.json
@@ -111,5 +111,5 @@
     "node": ">=18.20.8",
     "pnpm": ">=11.0.0-rc.0"
   },
-  "packageManager": "pnpm@11.0.0-rc.3"
+  "packageManager": "pnpm@11.0.0-rc.5"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,13 @@ packages:
   - .claude/hooks/*
 
 allowBuilds:
-  '@pnpm/exe': true
   esbuild: true
+
+# Refuse to run if the pnpm version on PATH differs from the packageManager
+# field in package.json. Our setup action pins pnpm via external-tools.json;
+# any drift should fail fast, not silently auto-download via @pnpm/exe
+# (which in rc.5 leaves a placeholder launcher that errors at runtime).
+pmOnFail: error
 
 overrides:
   defu: '>=6.1.7'


### PR DESCRIPTION
## Summary

- Bump `packageManager` from `pnpm@11.0.0-rc.3` to `pnpm@11.0.0-rc.5`.
- Add `pmOnFail: error` to `pnpm-workspace.yaml` so a pnpm version drift fails fast instead of silently auto-downloading via `@pnpm/exe` (whose rc.5 tarball leaves a placeholder launcher that errors at runtime — discovered during the socket-registry cascade that preceded this PR).
- Drop `'@pnpm/exe': true` from `allowBuilds` — no longer applicable now that `pmOnFail: error` prevents the self-download chain entirely.
- Bump all `SocketDev/socket-registry` action/workflow pins to `ebf1b48f962ea4978d63f18d5ac711cab94d597f` (propagation SHA for the pnpm rc.5 cascade in socket-registry). Unifies every socket-registry pin in this repo under a single SHA; leaf-action pins (`setup-git-signing`, `cleanup-git-signing`) resolve to identical content since those actions haven't changed.

Part of fleet-wide alignment to pnpm 11.0.0-rc.5. socket-registry internal cascade completed in commits through `d7b5d15a`; direct-push fleet repos (sdxgen, stuie, ultrathink, socket-lib, socket-packageurl-js, socket-btm) already updated. PR repos (socket-sdk-js, socket-cli) require human approval.

## Test plan

- [x] `pnpm install` with rc.5 reproduces the existing lockfile (no drift).
- [x] Pre-commit hooks pass (build + lint + staged tests).
- [ ] CI green on this PR.