### PR TITLE
style: rename catch (err|error) identifiers to catch (e)

### DIFF
--- a/src/file-upload.ts
+++ b/src/file-upload.ts
@@ -27,8 +27,8 @@ export function createRequestBodyForFilepaths(
     try {
       stream = createReadStream(absPath, { highWaterMark: 1024 * 1024 })
       /* c8 ignore next 13 - createReadStream throws synchronously only for type validation errors; file system errors (ENOENT, EISDIR) are emitted asynchronously */
-    } catch (error) {
-      const err = error as NodeJS.ErrnoException
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException
       let message = `Failed to read file: ${absPath}`
       if (err.code === 'ENOENT') {
         message += '\n→ File does not exist. Check the file path and try again.'
@@ -39,7 +39,7 @@ export function createRequestBodyForFilepaths(
       } else if (err.code) {
         message += `\n→ Error code: ${err.code}`
       }
-      throw new Error(message, { cause: error })
+      throw new Error(message, { cause: e })
     }
     form.append(relPath, stream, {
       contentType: 'application/octet-stream',
@@ -98,15 +98,15 @@ export async function createUploadRequest(
     }
 
     return response
-  } catch (error) {
+  } catch (e) {
     if (hooks?.onResponse) {
       hooks.onResponse({
         method,
         url,
         duration: Date.now() - startTime,
-        error: error as Error,
+        error: e as Error,
       })
     }
-    throw error
+    throw e
   }
 }

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -81,17 +81,17 @@ export async function createDeleteRequest(
     }
 
     return response
-  } catch (error) {
+  } catch (e) {
     if (hooks?.onResponse) {
       hooks.onResponse({
         method,
         url,
         duration: Date.now() - startTime,
-        error: error as Error,
+        error: e as Error,
       })
     }
 
-    throw error
+    throw e
   }
 }
 
@@ -140,7 +140,7 @@ export async function createGetRequest(
     }
 
     return response
-  } catch (error) {
+  } catch (e) {
     stopTimer({ error: true })
 
     if (hooks?.onResponse) {
@@ -148,11 +148,11 @@ export async function createGetRequest(
         method,
         url,
         duration: Date.now() - startTime,
-        error: error as Error,
+        error: e as Error,
       })
     }
 
-    throw error
+    throw e
   }
 }
 
@@ -210,7 +210,7 @@ export async function createRequestWithJson(
     }
 
     return response
-  } catch (error) {
+  } catch (e) {
     stopTimer({ error: true })
 
     if (hooks?.onResponse) {
@@ -218,11 +218,11 @@ export async function createRequestWithJson(
         method,
         url,
         duration: Date.now() - startTime,
-        error: error as Error,
+        error: e as Error,
       })
     }
 
-    throw error
+    throw e
   }
 }
 
@@ -315,9 +315,9 @@ export async function getResponseJson(
       throw unknownError
       /* c8 ignore stop */
     }
-  } catch (error) {
+  } catch (e) {
     stopTimer({ error: true })
-    throw error
+    throw e
   }
 }
 

--- a/test/unit/http-client.test.mts
+++ b/test/unit/http-client.test.mts
@@ -295,9 +295,9 @@ describe('HTTP Client - Error Handling', () => {
       try {
         await createGetRequest(invalidUrl, '/test', { timeout: 100 })
         expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeDefined()
-        expect(error instanceof Error).toBe(true)
+      } catch (e) {
+        expect(e).toBeDefined()
+        expect(e instanceof Error).toBe(true)
       }
     })
 
@@ -315,9 +315,9 @@ describe('HTTP Client - Error Handling', () => {
           },
         )
         expect.fail('Should have thrown an error')
-      } catch (error) {
-        expect(error).toBeDefined()
-        expect(error instanceof Error).toBe(true)
+      } catch (e) {
+        expect(e).toBeDefined()
+        expect(e instanceof Error).toBe(true)
       }
     })
 
@@ -328,9 +328,9 @@ describe('HTTP Client - Error Handling', () => {
         })
         await getResponseJson(response)
         expect.fail('Should have thrown a JSON parsing error')
-      } catch (error) {
-        expect(error).toBeDefined()
-        expect(error instanceof SyntaxError).toBe(true)
+      } catch (e) {
+        expect(e).toBeDefined()
+        expect(e instanceof SyntaxError).toBe(true)
       }
     })
   })


### PR DESCRIPTION
Mechanical rename across 3 files (src/file-upload.ts, src/http-client.ts, test/unit/http-client.test.mts) — 9 catch clauses converted. tsgo --noEmit clean.