### PR TITLE
chore(ci): bump socket-registry refs to f1b40c99 (npm-banner-validation fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
     with:
       test-script: 'pnpm run test --all --skip-build'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -46,14 +46,14 @@ jobs:
           echo "Sleeping for $delay seconds..."
           sleep $delay
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
 
       - name: Configure push credentials
         env:
           GH_TOKEN: ${{ github.token }}
         run: git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -145,5 +145,5 @@ jobs:
           > \`\`\`
           EOF
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
         if: always()

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write # To create GitHub releases
       id-token: write # For npm trusted publishing via OIDC
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   weekly-update:
-    uses: SocketDev/socket-registry/.github/workflows/weekly-update.yml@0371e83fccd7e2e5370b9ee7d0ddc882c9790210 # main
+    uses: SocketDev/socket-registry/.github/workflows/weekly-update.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
     with:
       test-setup-script: 'pnpm run build'
       test-script: 'pnpm test'


### PR DESCRIPTION
Bumps `SocketDev/socket-registry` workflow/action pins to `f1b40c99`.

Fixes a regression introduced by the previous propagation SHA (`0371e83f`, merged via #611). That commit added a runtime guard that calls `npm view @socketsecurity/lib version` to compute the floor; when the response was a Socket Firewall banner instead of a version string, the comparison function exploded with `[: <banner>: integer expression expected`.

`f1b40c99` validates `npm view` output against a plain-semver regex before using it, falling back to the hardcoded floor (`5.24.0`) when the response isn't semver. Same defensive check applied to the consumer's installed version.

socket-sdk-js already pins `@socketsecurity/lib` at `5.24.0` from #611 — this bump is mechanical, no consumer code changes.

## Test plan
- [ ] CI pipeline (check + matrix tests) passes
- [ ] Audit GitHub Actions check passes