### PR TITLE
chore(test): move vitest cache to node_modules/.cache

### DIFF
--- a/.config/vitest.config.isolated.mts
+++ b/.config/vitest.config.isolated.mts
@@ -28,7 +28,7 @@ const isCoverageEnabled =
   process.argv.some(arg => arg.includes('coverage'))
 
 export default defineConfig({
-  cacheDir: './.cache/vitest',
+  cacheDir: './node_modules/.cache/vitest',
   test: {
     globals: false,
     environment: 'node',

--- a/.config/vitest.config.mts
+++ b/.config/vitest.config.mts
@@ -23,7 +23,7 @@ if (isCoverageEnabled) {
 }
 
 export default defineConfig({
-  cacheDir: './.cache/vitest',
+  cacheDir: './node_modules/.cache/vitest',
   test: {
     globals: false,
     environment: 'node',

--- a/.gitignore
+++ b/.gitignore
@@ -52,12 +52,11 @@ desktop.ini
 *.sublime-*
 .idea
 
-# Cache directories
-**/.cache
 .eslintcache
 .tsbuildinfo
 
-# Runtime
+# Runtime (includes node_modules/.cache/ where vitest etc.
+# store scratch dirs — cleared by pnpm install automatically).
 node_modules
 **/node_modules
 

--- a/test/unit/utils.test.mts
+++ b/test/unit/utils.test.mts
@@ -97,8 +97,11 @@ describe('Path Resolution', () => {
       const result = resolveAbsPaths(paths)
 
       expect(result).toHaveLength(2)
-      expect(result[0]).toContain('socket-sdk-js/package.json')
-      expect(result[1]).toContain('socket-sdk-js/src/index.ts')
+      /* Suffix-based assertions — matching a specific repo dir
+       * name breaks when the test runs from a git worktree whose
+       * path segment differs from the primary checkout. */
+      expect(result[0]).toMatch(/\/package\.json$/)
+      expect(result[1]).toMatch(/\/src\/index\.ts$/)
       result.forEach(p => expect(path.isAbsolute(p)).toBe(true))
     })
 


### PR DESCRIPTION
## Summary

- Vitest's `cacheDir` moves from `./.cache/vitest` to `./node_modules/.cache/vitest` in both the main and isolated configs.
- `pnpm install` already wipes `node_modules/` (and its `.cache/` subdir), so this buys us free cache invalidation on every install — no dedicated clean step needed.
- Matches the pattern applied in `../socket-packageurl-js` and `../meander`.
- Drops `**/.cache` from `.gitignore` since nothing writes to a top-level `.cache/` anymore.

Adjacent fix: `test/unit/utils.test.mts`'s `resolveAbsPaths` assertion matched on `"socket-sdk-js/package.json"`, which breaks when the test runs from a git worktree whose directory name doesn't match the primary checkout. Switched to suffix matching (`/package.json$`, `/src/index.ts$`) which still verifies the path was resolved to absolute without baking in the repo's directory name. Caught while running the full suite from a `socket-sdk-js-cache/` worktree.

## Test plan

- [x] `pnpm exec vitest --config .config/vitest.config.mts --run` → 565/565 passing.
- [x] `pnpm run build` → clean.
- [x] Ran from a non-primary worktree path — the utils.test.mts fix confirmed.