### PR TITLE
chore(ci): bump socket-registry refs to b9918c72

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
     with:
       test-script: 'pnpm run test --all --skip-build'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -46,14 +46,14 @@ jobs:
           echo "Sleeping for $delay seconds..."
           sleep $delay
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
 
       - name: Configure push credentials
         env:
           GH_TOKEN: ${{ github.token }}
         run: git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -145,5 +145,5 @@ jobs:
           > \`\`\`
           EOF
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
         if: always()

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write # To create GitHub releases
       id-token: write # For npm trusted publishing via OIDC
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   weekly-update:
-    uses: SocketDev/socket-registry/.github/workflows/weekly-update.yml@f1b40c99a11f8f2f65a44c9e6c66e53470bd0b90 # main
+    uses: SocketDev/socket-registry/.github/workflows/weekly-update.yml@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
     with:
       test-setup-script: 'pnpm run build'
       test-script: 'pnpm test'


### PR DESCRIPTION
Propagation SHA bump. socket-registry's current main tip carries the .pnpmrc → pnpm-workspace.yaml rework (pnpm v11 doesn't read .pnpmrc; settings that matter live in pnpm-workspace.yaml or .npmrc).

socket-registry Layer 4 workflows (`_local-not-for-reuse-*`) are pinned to `b9918c72`; this PR pins the same SHA here so the fleet references the same socket-registry tip.

No workflow behavior change — the `.github/actions/*` contents are identical between `f1b40c99` and `b9918c72` (the intervening commits only touched `.pnpmrc` and `pnpm-workspace.yaml`).