### PR TITLE
chore(ci): cascade socket-registry pin to ea1986b8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ concurrency:
 jobs:
   ci:
     name: Run CI Pipeline
-    uses: SocketDev/socket-registry/.github/workflows/ci.yml@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+    uses: SocketDev/socket-registry/.github/workflows/ci.yml@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
     with:
       test-script: 'pnpm run test --all --skip-build'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -46,14 +46,14 @@ jobs:
           echo "Sleeping for $delay seconds..."
           sleep $delay
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-and-install@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
 
       - name: Configure push credentials
         env:
           GH_TOKEN: ${{ github.token }}
         run: git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
-      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/setup-git-signing@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         with:
           gpg-private-key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
 
@@ -145,5 +145,5 @@ jobs:
           > \`\`\`
           EOF
 
-      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+      - uses: SocketDev/socket-registry/.github/actions/cleanup-git-signing@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
         if: always()

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write # To create GitHub releases
       id-token: write # For npm trusted publishing via OIDC
-    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+    uses: SocketDev/socket-registry/.github/workflows/provenance.yml@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
     with:
       debug: ${{ inputs.debug }}
       dist-tag: ${{ inputs.dist-tag }}

--- a/.github/workflows/weekly-update.yml
+++ b/.github/workflows/weekly-update.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   weekly-update:
-    uses: SocketDev/socket-registry/.github/workflows/weekly-update.yml@b9918c72da5f4197c1af5cba60583efbeb64daf5 # main
+    uses: SocketDev/socket-registry/.github/workflows/weekly-update.yml@ea1986b8019fedee5fb38b485690b13ad8e0217f # main
     with:
       test-setup-script: 'pnpm run build'
       test-script: 'pnpm test'


### PR DESCRIPTION
## Summary

Bumps every `SocketDev/socket-registry@<sha>` reference from `b9918c72` to `ea1986b8`. Cascades the new `lib/*.mjs` helpers (jq, platform, install-tool, semver) and full musl + multi-flavor SFW support that landed in socket-registry's Layer 3 merge.

## Why

Eliminates the `cp: cannot stat ''` failure shape — empty `SOCKET_TOOL_*` env exports from the registry's setup/checkout/install actions are no longer reachable, since all JSON path reads now go through `node lib/jq.mjs` which exits non-zero on missing/empty values, and `set -e` propagates.

## Test plan

- [ ] CI pipeline runs against the new pin and passes
- [ ] Provenance publish path remains unaffected
- [ ] Weekly update job still resolves
- [ ] SDK generation workflow still picks up the action correctly