### PR TITLE
docs(claude+skills): CLAUDE.md restructure + new skills

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: security-reviewer
-description: Reviews findings from AgentShield + zizmor against socket-sdk-js's CLAUDE.md security rules and grades the result A-F. Spawned by the security-scan skill after the static scans run.
+description: Reviews findings from AgentShield + zizmor against the project's CLAUDE.md security rules and grades the result A-F. Spawned by the security-scan skill after the static scans run.
 tools: Read, Grep, Glob, Bash(git:*), Bash(rg:*), Bash(grep:*), Bash(find:*), Bash(ls:*), Bash(pnpm exec agentshield:*), Bash(zizmor:*), Bash(command -v:*), Bash(cat:*), Bash(head:*), Bash(tail:*)
 ---
 
@@ -18,7 +18,7 @@ Apply these rules from CLAUDE.md exactly:
 
 1. **Secrets**: Hardcoded API keys, passwords, tokens, private keys in code or config
 2. **Injection**: Command injection via shell: true or string interpolation in spawn/exec. Path traversal in file operations.
-3. **Dependencies**: npx/dlx usage. Unpinned versions (^ or ~). Missing minimumReleaseAge bypass justification. # zizmor: documentation-checklist
+3. **Dependencies**: npx/dlx usage. Unpinned versions (^ or ~). Missing soak-window bypass justification (pnpm-workspace.yaml `minimumReleaseAgeExclude`). # zizmor: documentation-checklist
 4. **File operations**: fs.rm without safeDelete. process.chdir usage. fetch() usage (must use lib's httpRequest).
 5. **GitHub Actions**: Unpinned action versions (must use full SHA). Secrets outside env blocks. Template injection from untrusted inputs.
 6. **Error handling**: Sensitive data in error messages. Stack traces exposed to users.

--- a/.claude/skills/_shared/path-guard-rule.md
+++ b/.claude/skills/_shared/path-guard-rule.md
@@ -1,7 +1,7 @@
 <!--
 Shared snippet — the canonical "1 path, 1 reference" rule text.
 Synced byte-identical across the Socket fleet via socket-repo-template's
-sync-scaffolding.mjs (SHARED_SKILL_FILES).
+sync-scaffolding.mts (SHARED_SKILL_FILES).
 
 This file is the source of truth for the rule's wording. Three artifacts
 embed (or paraphrase) it:
@@ -10,7 +10,7 @@ embed (or paraphrase) it:
   2. .claude/hooks/path-guard/README.md — what the hook blocks.
   3. .claude/skills/path-guard/SKILL.md — what the skill enforces.
 
-If the wording changes here, re-run `node scripts/sync-scaffolding.mjs
+If the wording changes here, re-run `node scripts/sync-scaffolding.mts
 --all --fix` from socket-repo-template to propagate.
 -->
 

--- a/.claude/skills/path-guard/SKILL.md
+++ b/.claude/skills/path-guard/SKILL.md
@@ -2,7 +2,7 @@
 name: path-guard
 description: Audit and fix path duplication in this Socket repo. Apply the strict "1 path, 1 reference" rule — every build/test/runtime/config path is constructed exactly once; everywhere else references the constructed value. Default mode finds and fixes; `check` mode reports only; `install` mode drops the gate + hook + rule into a fresh repo.
 user-invocable: true
-allowed-tools: Task, Bash, Read, Edit, Write, Grep, Glob, AskUserQuestion
+allowed-tools: Task, Read, Edit, Write, Grep, Glob, AskUserQuestion, Bash(pnpm run check:*), Bash(node scripts/check-paths:*), Bash(rg:*), Bash(grep:*), Bash(find:*), Bash(git:*)
 ---
 
 # path-guard

--- a/.claude/skills/programmatic-claude-lockdown/SKILL.md
+++ b/.claude/skills/programmatic-claude-lockdown/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: programmatic-claude-lockdown
+description: Reference for locking down programmatic Claude invocations (the `claude` CLI in workflows/scripts, the `@anthropic-ai/claude-agent-sdk` `query()` in code). Loads on demand when writing or reviewing any callsite that runs Claude programmatically. Source: https://code.claude.com/docs/en/agent-sdk/permissions.
+user-invocable: false
+allowed-tools: Read, Grep, Glob
+---
+
+# Programmatic Claude lockdown
+
+**Rule:** every programmatic Claude callsite sets four flags. Skip any one and a future edit silently widens the surface.
+
+## The four flags
+
+| Layer | SDK option | CLI flag | What it does |
+|---|---|---|---|
+| Definition | `tools` | `--tools` | Base set the model is told about. Tools not listed are invisible — no `tool_use` block possible. |
+| Auto-approve | `allowedTools` | `--allowedTools` | Step 4. Listed tools run without invoking `canUseTool`. |
+| Deny | `disallowedTools` | `--disallowedTools` | Step 2. Wins even against `bypassPermissions`. Defense-in-depth. |
+| Mode | `permissionMode: 'dontAsk'` | `--permission-mode dontAsk` | Step 3. Unmatched tools denied without falling through to a missing `canUseTool`. |
+
+The official permission flow (1) hooks → (2) deny rules → (3) permission mode → (4) allow rules → (5) `canUseTool`. In `dontAsk` mode step 5 is skipped — denied. The doc states verbatim: *"`allowedTools` and `disallowedTools` ... control whether a tool call is approved, not whether the tool is available."* Availability is `tools`.
+
+## Recipe — read-only agent (audit, classify, summarize)
+
+```ts
+import { query } from '@anthropic-ai/claude-agent-sdk'
+
+query({
+  prompt: '...',
+  options: {
+    tools: ['Read', 'Grep', 'Glob'],
+    allowedTools: ['Read', 'Grep', 'Glob'],
+    disallowedTools: ['Agent', 'Bash', 'Edit', 'NotebookEdit', 'Task', 'WebFetch', 'WebSearch', 'Write'],
+    permissionMode: 'dontAsk',
+  },
+})
+```
+
+CLI form for workflow YAML / shell scripts:
+
+```yaml
+claude --print \
+  --tools "Read" "Grep" "Glob" \
+  --allowedTools "Read" "Grep" "Glob" \
+  --disallowedTools "Agent" "Bash" "Edit" "NotebookEdit" "Task" "WebFetch" "WebSearch" "Write" \
+  --permission-mode dontAsk \
+  --model "$MODEL" \
+  --max-turns 25 \
+  "<prompt>"
+```
+
+## Recipe — agent that needs Bash (e.g. `/updating`: pnpm + git + jq)
+
+Narrow `Bash(...)` patterns surgically. Block dangerous Bash patterns explicitly. Fleet rules: no `npx`/`pnpm dlx`/`yarn dlx`; no `curl`/`wget` exfil; no destructive `rm -rf`; no `sudo`. Build the deny list as shell vars so the npx/dlx denials can carry the `# zizmor:` exemption marker (the pre-commit `scanNpxDlx` hook treats those literal strings as the prohibited tools, not as exemptions, unless the line is tagged):
+
+```yaml
+DISALLOW_BASE='Agent Task NotebookEdit WebFetch WebSearch Bash(curl:*) Bash(wget:*) Bash(rm -rf*) Bash(sudo:*)'
+DISALLOW_PKG_EXEC='Bash(npx:*) Bash(pnpm dlx:*) Bash(yarn dlx:*)'  # zizmor: documentation-prohibition
+claude --print \
+  --tools "Bash" "Read" "Write" "Edit" "Glob" "Grep" \
+  --allowedTools "Bash(pnpm:*)" "Bash(git:*)" "Bash(jq:*)" "Read" "Write" "Edit" "Glob" "Grep" \
+  --disallowedTools $DISALLOW_BASE $DISALLOW_PKG_EXEC \
+  --permission-mode dontAsk \
+  --model "$MODEL" --max-turns 25 \
+  "<prompt>"
+```
+
+## Never
+
+- ❌ `permissionMode: 'default'` in headless contexts — falls through to a missing `canUseTool`. Behavior undefined.
+- ❌ `permissionMode: 'bypassPermissions'` / `allowDangerouslySkipPermissions: true`.
+- ❌ Omitting `tools` — SDK default is the full claude_code preset.
+- ❌ `Agent` / `Task` permitted — sub-agents inherit modes and can escape per-subagent restrictions when the parent is `bypassPermissions`/`acceptEdits`/`auto`.
+
+## Reference implementation
+
+`socket-lib/tools/prim/src/disambiguate.mts` — canonical SDK-form callsite. The file header documents each flag against the eval-flow step it enforces.
+
+`socket-lib/tools/prim/test/disambiguate.test.mts` — source-text guards that fail the build if `BASE_TOOLS` widens, if `tools: BASE_TOOLS` is unwired, if `permissionMode` drifts from `'dontAsk'`, or if `bypassPermissions` / `allowDangerouslySkipPermissions: true` ever appears. Mirror this pattern in any new callsite.
+
+## Existing fleet callsites
+
+- `socket-registry/.github/workflows/weekly-update.yml` — two `claude --print` invocations (run `/updating` skill, fix test failures). Bash recipe above.
+- `socket-lib/tools/prim/src/disambiguate.mts` — read-only recipe above (`query()` SDK form).

--- a/.claude/skills/promise-race-pitfall/SKILL.md
+++ b/.claude/skills/promise-race-pitfall/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: promise-race-pitfall
+description: Reference for the `Promise.race` cross-iteration handler-leak bug. Loads on demand when writing or reviewing concurrency code that uses `Promise.race`, `Promise.any`, or hand-rolled concurrency limiters.
+---
+
+# Promise.race in loops — the handler-leak pitfall
+
+**Never re-race the same pool of promises across loop iterations.** Each call to `Promise.race([A, B, …])` attaches fresh `.then` handlers to every arm. A promise that survives N iterations accumulates N handler sets. See [nodejs/node#17469](https://github.com/nodejs/node/issues/17469) and [`@watchable/unpromise`](https://github.com/watchable/unpromise).
+
+## Patterns
+
+- **Safe** — both arms created per call:
+
+  ```ts
+  const value = await Promise.race([
+    fetchSomething(),
+    new Promise((_, r) => setTimeout(() => r(new Error('timeout')), 5000)),
+  ])
+  ```
+
+- **Leaky** — `pool` survives across iterations, accumulating handlers:
+
+  ```ts
+  while (queue.length) {
+    const winner = await Promise.race(pool)  // ← N handlers per arm by iteration N
+    pool = pool.filter(p => p !== winner)
+  }
+  ```
+
+  Same hazard for `Promise.any` and any long-lived arm such as an interrupt signal.
+
+## The fix
+
+Use a single-waiter "slot available" signal. Each task's `.then` resolves a one-shot `promiseWithResolvers` that the loop awaits, then replaces. No persistent pool, nothing to stack.
+
+```ts
+let signal = Promise.withResolvers<Task>()
+function startTask(task: Task) {
+  task.run().then(() => {
+    const prev = signal
+    signal = Promise.withResolvers<Task>()
+    prev.resolve(task)
+  })
+}
+while (queue.length) {
+  // launch up to N tasks
+  while (running < N && queue.length) startTask(queue.shift()!)
+  const finished = await signal.promise
+  running -= 1
+}
+```
+
+The arm being awaited is *always fresh*; nothing accumulates handlers.
+
+## Quick check
+
+Before merging concurrency code, ask: *does any arm of a `Promise.race`/`Promise.any` outlive the call?* If yes, refactor to the single-waiter signal.

--- a/.socket-repo-template.json
+++ b/.socket-repo-template.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "./socket-repo-template-schema.json",
+  "schemaVersion": 1,
+  "repoName": "socket-sdk-js",
+  "kind": "single-package"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,150 +2,132 @@
 
 🚨 **MANDATORY**: Act as principal-level engineer with deep expertise in TypeScript, Node.js, and SDK development.
 
-## USER CONTEXT
+<!-- BEGIN FLEET-CANONICAL — sync via socket-repo-template/scripts/sync-scaffolding.mts. Do not edit downstream. -->
 
-- Identify users by git credentials; use their actual name, never "the user"
-- Use "you/your" when speaking directly; use names when referencing contributions
+## 📚 Fleet Standards
 
-## 🚨 PARALLEL CLAUDE SESSIONS - WORKTREE REQUIRED
+### Identifying users
 
-**This repo may have multiple Claude sessions running concurrently against the same checkout, against parallel git worktrees, or against sibling clones.** Several common git operations are hostile to that and silently destroy or hijack the other session's work.
+Identify users by git credentials and use their actual name. Use "you/your" when speaking directly; use names when referencing contributions.
 
-- **FORBIDDEN in the primary checkout** (the one another Claude may be editing):
-  - `git stash` — shared stash store; another session can `pop` yours.
-  - `git add -A` / `git add .` — sweeps files belonging to other sessions.
-  - `git checkout <branch>` / `git switch <branch>` — yanks the working tree out from under another session.
-  - `git reset --hard` against a non-HEAD ref — discards another session's commits.
-- **REQUIRED for branch work**: spawn a worktree instead of switching branches in place. Each worktree has its own HEAD, so branch operations inside it are safe.
+### Parallel Claude sessions
 
-  ```bash
-  # From the primary checkout — does NOT touch the working tree here.
-  git worktree add -b <task-branch> ../<repo>-<task> main
-  cd ../<repo>-<task>
-  # edit, commit, push from here; the primary checkout is untouched.
-  cd -
-  git worktree remove ../<repo>-<task>
-  ```
+This repo may have multiple Claude sessions running concurrently against the same checkout, against parallel git worktrees, or against sibling clones. Several common git operations are hostile to that.
 
-- **REQUIRED for staging**: surgical `git add <specific-file> [<file>…]` with explicit paths. Never `-A` / `.`.
-- **If you need a quick WIP save**: commit on a new branch from inside a worktree, not a stash.
-- **NEVER revert files you didn't touch.** If `git status` shows files you didn't modify, those belong to another session, an upstream pull, or a hook side-effect — leave them alone. Specifically: do not run `git checkout -- <unrelated-path>` to "clean up" the diff before committing, and do not include unrelated paths in `git add`. Stage only the explicit files you edited.
+**Forbidden in the primary checkout:**
+
+- `git stash` — shared store; another session can `pop` yours
+- `git add -A` / `git add .` — sweeps files from other sessions
+- `git checkout <branch>` / `git switch <branch>` — yanks the working tree out from under another session
+- `git reset --hard` against a non-HEAD ref — discards another session's commits
+
+**Required for branch work:** spawn a worktree.
+
+```bash
+git worktree add -b <task-branch> ../<repo>-<task> main
+cd ../<repo>-<task>
+# edit / commit / push from here; primary checkout is untouched
+git worktree remove ../<repo>-<task>
+```
+
+**Required for staging:** surgical `git add <specific-file>`. Never `-A` / `.`.
+
+**Never revert files you didn't touch.** If `git status` shows unfamiliar changes, leave them — they belong to another session, an upstream pull, or a hook side-effect.
 
 The umbrella rule: never run a git command that mutates state belonging to a path other than the file you just edited.
 
-## 📚 SHARED STANDARDS
+### Public-surface hygiene
 
-- Commits: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) `<type>(<scope>): <description>` — NO AI attribution
-- **Open PRs:** when adding commits to an OPEN PR, ALWAYS update the PR title and description to match the new scope. A title like `chore: foo` after you've added security-fix and docs commits to it is now a lie. Use `gh pr edit <num> --title "..." --body "..."` (or `--body-file`) and rewrite the body so it reflects every commit on the branch, grouped by theme. The reviewer should be able to read the PR description and know what's in it without scrolling commits.
-- Scripts: Prefer `pnpm run foo --flag` over `foo:bar` scripts
-- Dependencies: After `package.json` edits, run `pnpm install`
-- Backward Compatibility: 🚨 FORBIDDEN to maintain — actively remove when encountered
-- 🚨 **NEVER use `npx`, `pnpm dlx`, or `yarn dlx`** — use `pnpm exec <package>` or `pnpm run <script>`. Add tools as pinned devDependencies first.
-- **minimumReleaseAge**: NEVER add packages to `minimumReleaseAgeExclude` in CI. Locally, ASK before adding — the age threshold is a security control.
-- 🚨 **NEVER mention private repos or internal project names** in commits, PR titles/descriptions/comments, issues, release notes, or any public-surface text. Internal codenames, unreleased product names, internal tooling repo names not on the public org page, customer names, partner names — none belong in public surfaces. **Omit the reference entirely.** Don't substitute a placeholder ("an internal tool", "a downstream consumer", etc.) — the placeholder itself is a tell that something is being elided. Rewrite the sentence to not need the reference at all.
-- 🚨 **NEVER trigger Publish / Release / Provenance / Build-Release workflows** — no `gh workflow run`, `gh workflow dispatch`, or `gh api .../dispatches`. Workflow dispatches are irrevocable: Publish workflows push npm versions (unpublishable after 24h), Build/Release workflows pin GitHub releases by SHA, container workflows push immutable tags. Even build workflows with a `dry_run` input still treat the dispatch itself as the prod trigger. The user runs workflow_dispatch jobs manually after CI passes on the release commit + tag — Claude **never** dispatches them. If the user asks for a publish, tell them to run the command in their own terminal (or the GitHub Actions UI).
-- File existence: ALWAYS `existsSync` from `node:fs`. NEVER `fs.access`, `fs.stat`-for-existence, or an async `fileExists` wrapper. Import form: `import { existsSync, promises as fs } from 'node:fs'`.
-- Null-prototype objects: ALWAYS use `{ __proto__: null, ...rest }` for config, return, and internal-state objects. Prevents prototype pollution and accidental inheritance. See `src/socket-sdk-class.ts` and `src/file-upload.ts` for examples.
-- Linear references: NEVER reference Linear issues (e.g. `SOC-123`, `ENG-456`, Linear URLs) in code, code comments, or PR titles/descriptions/review comments. Keep the codebase and PR history tool-agnostic — tracking lives in Linear.
+🚨 The four rules below have hooks that re-print the rule on every public-surface `git` / `gh` command. The rules apply even when the hooks are not installed.
 
-### Sorting
+- **Real customer / company names** — never write one into a commit, PR, issue, comment, or release note. Replace with `Acme Inc` or rewrite the sentence to not need the reference. (No enumerated denylist exists — a denylist is itself a leak.)
+- **Private repos / internal project names** — never mention. Omit the reference entirely; don't substitute "an internal tool" — the placeholder is a tell.
+- **Linear refs** — never put `SOC-123`/`ENG-456`/Linear URLs in code, comments, or PR text. Linear lives in Linear.
+- **Publish / release / build-release workflows** — never `gh workflow run|dispatch` or `gh api …/dispatches`. Dispatches are irrevocable. The user runs them manually.
 
-Sort lists alphanumerically (literal byte order, ASCII before letters). Apply this to:
+### Commits & PRs
 
-- **Config lists** — `permissions.allow` / `permissions.deny` in `.claude/settings.json`, `external-tools.json` checksum keys, allowlists in workflow YAML.
-- **Object key entries** — sort keys in plain JSON config + return-shape literals + internal-state objects. (Exception: `__proto__: null` always comes first, ahead of any data keys.)
-- **Import specifiers** — sort named imports inside a single statement: `import { encrypt, randomDataKey, wrapKey } from './crypto.mts'`. Imports that say `import type` follow the same rule. Statement _order_ is the project's existing convention (`node:` → external → local → types) — that's separate from specifier order _within_ a statement.
-- **Method / function source placement** — within a module, sort top-level functions alphabetically. Convention: private functions (lowercase / un-exported) sort first, exported functions second. The first-line `export` keyword is the divider.
-- **Array literals** — when the array is a config list, allowlist, or set-like collection. Position-bearing arrays (e.g. argv, anything where index matters semantically) keep their meaningful order.
+- Conventional Commits `<type>(<scope>): <description>` — NO AI attribution.
+- **When adding commits to an OPEN PR**, update the PR title and description to match the new scope. Use `gh pr edit <num> --title … --body …`. The reviewer should know what's in the PR without scrolling commits.
+- **Replying to Cursor Bugbot** — reply on the inline review-comment thread, not as a detached PR comment: `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies -X POST -f body=…`.
 
-When in doubt, sort. The cost of a sorted list that didn't need to be is approximately zero; the cost of an unsorted list that did need to be is a merge conflict.
+### Programmatic Claude calls
 
-### Paths: One Path, One Reference
+🚨 Workflows / skills / scripts that invoke `claude` CLI or `@anthropic-ai/claude-agent-sdk` MUST set all four lockdown flags: `tools`, `allowedTools`, `disallowedTools`, `permissionMode: 'dontAsk'`. Never `default` mode in headless contexts. Never `bypassPermissions`. See `.claude/skills/programmatic-claude-lockdown/SKILL.md`.
 
-**If a path appears in two places, that's a bug.** Every artifact (build output, cache directory, generated file, config location) lives at exactly one canonical location, and that location is defined in exactly one place — typically a `paths.mts` (or equivalent path helper) module. Everything else — other scripts, READMEs, Dockerfiles, workflows, tests — derives from that source. No hand-assembled `path.join(...)` strings outside the module that owns them.
+### Tooling
 
-- **Within a package**: every script imports its own path module. No script computes paths from raw segments.
-- **Across packages**: when package B consumes package A's artifact, B imports A's path module (or a typed helper exported from it) — never reconstructs the path from string segments. The classic failure: A adds a new path segment (e.g. inserts a `wasm/` directory), B's hand-built copy of the path drifts, builds break.
-- **Doc strings**: README "Output:" lines and `@fileoverview` comments describe the path; they don't _encode_ it for tools to parse. The doc is for humans only — and even there, it must match what the path module actually produces, verified by running the function.
-- **Workflows / Dockerfiles**: GitHub Actions YAML and Dockerfiles can't `import` TS, so they're allowed to reference the path string directly — but they MUST add a comment pointing at the canonical path module so the next person editing knows where the source of truth lives, and any path string must match the module byte-for-byte. If you find yourself writing the same path twice in one workflow, hoist it to a step output or a job-level env var; reference that everywhere downstream.
-- **Comments that re-state the path**: forbidden. A comment like `// Path mirrors getBuildPaths(): build/<mode>/<arch>/out/Final/...` is duplication wearing a comment costume. The import statement is the comment.
+- **Package manager**: `pnpm`. Run scripts via `pnpm run foo --flag`, never `foo:bar`. After `package.json` edits, `pnpm install`.
+- 🚨 NEVER use `npx`, `pnpm dlx`, or `yarn dlx` — use `pnpm exec <package>` or `pnpm run <script>` # socket-hook: allow npx
+- **Soak window** (pnpm-workspace.yaml `minimumReleaseAge`, default 7 days) — never add packages to `minimumReleaseAgeExclude` in CI. Locally, ASK before adding (security control).
+- **Backward compatibility** — FORBIDDEN to maintain. Actively remove when encountered.
 
-When you spot duplication, the answer is never "update both" — the answer is "delete one and import the other." Fix the architecture, not the symptom.
+### Code style
 
-### Inclusive Language
-
-Use precise, neutral terms over historical metaphors that imply hierarchy or exclusion. The substitutes are not euphemisms — they're more _accurate_ (a list of allowed values genuinely is an "allowlist"; "whitelist" is a metaphor that hides what the list does).
-
-| Replace                          | With                                                |
-| -------------------------------- | --------------------------------------------------- |
-| `whitelist` / `whitelisted`      | `allowlist` / `allowed` / `allowlisted`             |
-| `blacklist` / `blacklisted`      | `denylist` / `denied` / `blocklisted` / `blocked`   |
-| `master` (branch, process, copy) | `main` (branch); `primary` / `controller` (process) |
-| `slave`                          | `replica`, `worker`, `secondary`, `follower`        |
-| `grandfathered`                  | `legacy`, `pre-existing`, `exempted`                |
-| `sanity check`                   | `quick check`, `confidence check`, `smoke test`     |
-| `dummy` (placeholder)            | `placeholder`, `stub`                               |
-
-Apply across **code** (identifiers, comments, string literals), **docs** (READMEs, CLAUDE.md, markdown), **config files** (YAML, JSON), **commit messages**, **PR titles/descriptions**, and **CI logs** you control.
-
-Two exceptions where the legacy term must remain (because changing it breaks something external):
-
-- **Third-party APIs / upstream code**: when interfacing with an external API field literally named `whitelist`, keep the field name; rename your local variable. E.g. `const allowedDomains = response.whitelist`.
-- **Vendored upstream sources**: don't rewrite vendored code (`vendor/**`, `upstream/**`, `**/fixtures/**`). Patch around it if needed.
-
-When you encounter a legacy term during unrelated work, fix it inline — don't defer.
-
-### Promise.race in loops
-
-**NEVER re-race the same pool of promises across loop iterations.** Each call to `Promise.race([A, B, ...])` attaches fresh `.then` handlers to every arm; a promise that survives N iterations accumulates N handler sets. See [nodejs/node#17469](https://github.com/nodejs/node/issues/17469) and `@watchable/unpromise`.
-
-- **Safe**: `Promise.race([fresh1, fresh2])` where both arms are created per call (e.g. one-shot `withTimeout` wrappers).
-- **Leaky**: `Promise.race(pool)` inside a loop where `pool` persists across iterations (the classic concurrency-limiter bug) — also applies to `Promise.any` and long-lived arms like interrupt signals.
-- **Fix**: single-waiter "slot available" signal — each task's `.then` resolves a one-shot `promiseWithResolvers` that the loop awaits, then replaces. No persistent pool, nothing to stack.
-
----
-
-## EMOJI & OUTPUT STYLE
-
-**Terminal symbols** (from `@socketsecurity/lib/logger` LOG_SYMBOLS): ✓ (green), ✗ (red), ⚠ (yellow), ℹ (blue), → (cyan). Use logger methods, never manually apply colors.
-
-```javascript
-import { getDefaultLogger } from '@socketsecurity/lib/logger'
-const logger = getDefaultLogger()
-
-logger.success(msg) // Green ✓
-logger.fail(msg) // Red ✗
-logger.warn(msg) // Yellow ⚠
-logger.info(msg) // Blue ℹ
-logger.step(msg) // Cyan →
-```
-
-Emojis allowed sparingly: 📦 💡 🚀 🎉. Prefer text-based symbols for terminal compatibility.
-
----
+- **Comments** — default to none. Write one only when the WHY is non-obvious to a senior engineer.
+- **Completion** — never leave `TODO` / `FIXME` / `XXX` / shims / stubs / placeholders. Finish 100%. If too large for one pass, ask before cutting scope.
+- **`null` vs `undefined`** — use `undefined`. `null` is allowed only for `__proto__: null` or external API requirements.
+- **Object literals** — `{ __proto__: null, ... }` for config / return / internal-state.
+- **Imports** — no dynamic `await import()`. `node:fs` cherry-picks (`existsSync`, `promises as fs`); `path` / `os` / `url` / `crypto` use default imports. Exception: `fileURLToPath` from `node:url`.
+- **HTTP** — never `fetch()`. Use `httpJson` / `httpText` / `httpRequest` from `@socketsecurity/lib/http-request`.
+- **File existence** — `existsSync` from `node:fs`. Never `fs.access` / `fs.stat`-for-existence / async `fileExists` wrapper.
+- **File deletion** — route every delete through `safeDelete()` / `safeDeleteSync()` from `@socketsecurity/lib/fs`. Never `fs.rm` / `fs.unlink` / `fs.rmdir` / `rm -rf` directly — even for one known file.
+- **Edits** — Edit tool, never `sed` / `awk`.
+- **Inclusive language** — see [`docs/references/inclusive-language.md`](docs/references/inclusive-language.md) for the substitution table.
+- **Sorting** — sort lists alphanumerically; details in [`docs/references/sorting.md`](docs/references/sorting.md). When in doubt, sort.
+- **`Promise.race` / `Promise.any` in loops** — never re-race a pool that survives across iterations (the handlers stack). See `.claude/skills/promise-race-pitfall/SKILL.md`.
 
 ### 1 path, 1 reference
 
-**A path is _constructed_ exactly once. Everywhere else _references_ the constructed value.**
+A path is constructed exactly once. Everywhere else references the constructed value.
 
-Referencing a single computed path many times is fine — that's the whole point of computing it once. What's banned is _re-constructing_ the same path in multiple places, because that's where drift is born.
+- **Within a package**: every script imports its own `scripts/paths.mts`. No `path.join('build', mode, …)` outside that module.
+- **Across packages**: package B imports package A's `paths.mts` via the workspace `exports` field. Never `path.join(PKG, '..', '<sibling>', 'build', …)`.
+- **Workflows / Dockerfiles / shell** can't `import` TS — construct once, reference by output / `ENV` / variable.
 
-- **Within a package**: every script imports its own `scripts/paths.mts` (or `lib/paths.mts`). No `path.join('build', mode, ...)` outside that module.
-- **Across packages**: when package B consumes package A's output, B imports A's `paths.mts` via the workspace `exports` field. Never `path.join(PKG, '..', '<sibling>', 'build', ...)`.
-- **Workflows, Dockerfiles, shell scripts**: they can't `import` TS, so they construct the string once and reference it everywhere downstream. Workflows: a "Compute paths" step exposes `steps.paths.outputs.final_dir`; later steps read `${{ steps.paths.outputs.final_dir }}`. Dockerfiles/shell: assign once to a variable / `ENV`, reference by name thereafter. Each canonical construction carries a comment naming the source-of-truth `paths.mts`. **Re-building** the same path in a second step is the violation, not referring to the constructed value many times.
-- **Comments**: may describe path _structure_ with placeholders ("`<mode>/<arch>`") but should not encode a complete literal path string. The import statement IS the comment.
+Three-level enforcement: `.claude/hooks/path-guard/` blocks at edit time; `scripts/check-paths.mts` is the whole-repo gate run by `pnpm check`; `/path-guard` is the audit-and-fix skill. Find the canonical owner and import from it.
 
-Code execution takes priority over docs: violations in `.mts`/`.cts`, Makefiles, Dockerfiles, workflow YAML, and shell scripts are blocking. README and doc-comment violations are advisory unless they contain a fully-qualified path with no parametric placeholders.
+### Background Bash
 
-**Three-level enforcement:**
+Never use `Bash(run_in_background: true)` for test / build commands (`vitest`, `pnpm test`, `pnpm build`, `tsgo`). Backgrounded runs you don't poll get abandoned and leak Node workers. Background mode is for dev servers and long migrations whose results you'll consume. If a run hangs, kill it: `pkill -f "vitest/dist/workers"`. The `.claude/hooks/stale-process-sweeper/` `Stop` hook reaps true orphans as a safety net.
 
-- **Hook** — `.claude/hooks/path-guard/` blocks `Edit`/`Write` calls that would introduce a violation in a `.mts`/`.cts` file at edit time.
-- **Gate** — `scripts/check-paths.mts` runs in `pnpm check`. Fails the build on any violation that isn't allowlisted in `.github/paths-allowlist.yml`.
-- **Skill** — `/path-guard` audits the repo and fixes findings; `/path-guard check` reports only; `/path-guard install` drops the gate + hook + rule into a fresh repo.
+### Judgment & self-evaluation
 
-The mantra is intentionally short so it sticks: **1 path, 1 reference**. When in doubt, find the canonical owner and import from it.
+- If the request is based on a misconception, say so before executing.
+- If you spot an adjacent bug, flag it: "I also noticed X — want me to fix it?"
+- Fix warnings (lint / type / build / runtime) when you see them — don't leave them for later.
+- **Default to perfectionist** when you have latitude. "Works now" ≠ "right."
+- Before calling done: perfectionist vs. pragmatist views. Default perfectionist absent a signal.
+- If a fix fails twice: stop, re-read top-down, state where the mental model was wrong, try something fundamentally different.
 
-## 🏗️ SDK-SPECIFIC
+### Error messages
+
+An error message is UI. The reader should fix the problem from the message alone. Four ingredients in order:
+
+1. **What** — the rule, not the fallout (`must be lowercase`, not `invalid`).
+2. **Where** — exact file / line / key / field / flag.
+3. **Saw vs. wanted** — the bad value and the allowed shape or set.
+4. **Fix** — one imperative action (`rename the key to …`).
+
+Use `isError` / `isErrnoException` / `errorMessage` / `errorStack` from `@socketsecurity/lib/errors` over hand-rolled checks. Use `joinAnd` / `joinOr` from `@socketsecurity/lib/arrays` for allowed-set lists. Full guidance in [`docs/references/error-messages.md`](docs/references/error-messages.md).
+
+### Token hygiene
+
+🚨 Never emit the raw value of any secret to tool output, commits, comments, or replies. The `.claude/hooks/token-guard/` `PreToolUse` hook blocks the deterministic patterns (literal token shapes, env dumps, `.env*` reads, unfiltered `curl -H "Authorization:"`, sensitive-name commands without redaction). When the hook blocks a command, rewrite — don't bypass.
+
+Behavior the hook can't catch: redact `token` / `jwt` / `access_token` / `refresh_token` / `api_key` / `secret` / `password` / `authorization` fields when citing API responses. Show key _names_ only when displaying `.env.local`. If a user pastes a secret, treat it as compromised and ask them to rotate.
+
+Full hook spec in [`.claude/hooks/token-guard/README.md`](.claude/hooks/token-guard/README.md).
+
+### Agents & skills
+
+- `/security-scan` — AgentShield + zizmor audit
+- `/quality-scan` — quality analysis
+- Shared subskills in `.claude/skills/_shared/`
+
+<!-- END FLEET-CANONICAL -->
+
+## 🏗️ SDK-Specific
 
 ### Architecture
 
@@ -168,30 +150,6 @@ Features: TypeScript support, API client, package analysis, security scanning, o
 - **Lint**: `pnpm run lint`
 - **Check all**: `pnpm check`
 - **Coverage**: `pnpm run cover`
-
-## ERROR MESSAGES
-
-An error message is UI. The reader should be able to fix the problem from the message alone, without opening your source. Every message needs four ingredients, in order:
-
-1. **What** — the rule that was broken, not the fallout (`must be non-empty`, not `invalid`).
-2. **Where** — exact method, argument, field, or URL.
-3. **Saw vs. wanted** — the bad value and the allowed shape or set.
-4. **Fix** — one concrete action, imperative voice (`pass an org slug`, not `the org slug was missing`).
-
-SDK errors are **terse** — callers may `catch` and match on message text, so every word counts. One sentence covering all four is the norm: `throw new Error('orgSlug is required')`.
-
-Prefer the caught-value helpers from `@socketsecurity/lib/errors` (`isError`, `isErrnoException`, `errorMessage`, `errorStack`) over hand-rolled `instanceof Error` / `'code' in e` checks. For allowed-set / conflict lists, use `joinAnd` / `joinOr` from `@socketsecurity/lib/arrays`.
-
-See `docs/references/error-messages.md` for length tiers (validator / programmatic), the full rule list, worked examples, anti-patterns, and helper signatures.
-
-## Agents & Skills
-
-- `/security-scan` — AgentShield + zizmor security audit
-- `/quality-scan` — comprehensive code quality analysis
-- `/quality-loop` — scan and fix iteratively
-- Agents: `code-reviewer`, `security-reviewer`, `refactor-cleaner` (in `.claude/agents/`)
-- Shared subskills in `.claude/skills/_shared/`
-- Pipeline state tracked in `.claude/ops/queue.yaml`
 
 ### Configuration Files
 
@@ -295,55 +253,11 @@ Also available: `setupTestEnvironment()` (nock only), `createTestClient()` (clie
 - Custom runner: `scripts/test.mts` with glob expansion
 - Memory: auto heap (CI 8GB, local 4GB)
 
-### Changelog Management
-
-🚨 MANDATORY for version bumps:
-
-- Check OpenAPI updates: `git diff v{prev}..HEAD -- types/`
-- Document user-facing changes: new endpoints, parameter changes, new enum values, breaking contracts
-- Focus on user impact, not internal infrastructure
-
 ### Debugging
 
 - CI uses published npm packages, not local
 - Package detection: use `existsSync()` not `fs.access()`
 - Test failures: check unused nock mocks and cleanup
-
-### Judgment Protocol
-
-- If the user's request is based on a misconception, say so before executing
-- If you spot a bug adjacent to what was asked, flag it: "I also noticed X — want me to fix it?"
-- You are a collaborator, not just an executor
-- When a warning (lint, type-check, build, runtime) surfaces in code you're already editing, fix it in the same change — don't leave it for later. For warnings in unrelated files, flag them instead of drive-by fixing.
-- **Default to perfectionist mindset**: when you have latitude to choose, pick the maximally correct option — no shortcuts, no cosmetic deferrals. Fix state that _looks_ stale even if not load-bearing. If pragmatism is the right call, the user will ask for it explicitly. "Works now" ≠ "right."
-
-### Self-Evaluation
-
-- Before calling done: present two views — perfectionist reject vs. pragmatist ship — and let the user decide. If the user gives no signal, default to perfectionist: do the fuller fix.
-- If a fix fails twice: stop, re-read top-down, state where the mental model was wrong, try something fundamentally different
-
-### Completion Protocol
-
-- **NEVER claim done at 80%** — finish 100% before reporting
-- Fix forward, don't revert; reverting requires explicit user approval
-- After EVERY code change: build, test, verify, commit — one atomic unit
-
-### File System as State
-
-Use `.claude/` (gitignored) for plans, intermediate analysis, logs, and cross-session context. Don't hold large analysis in context.
-
-### Self-Improvement
-
-- After ANY user correction: log the pattern so the mistake isn't repeated
-- Convert mistakes into strict rules
-- After fixing a bug: explain why it happened and what category it represents
-
-### Context & Edit Safety
-
-- After 10+ messages: re-read files before editing
-- Before/after every edit: re-read to confirm
-- Tool results over 50K chars are silently truncated — narrow scope and re-run if sparse
-- Tasks touching >5 files: use sub-agents with worktree isolation
 
 ### SDK Notes
 

--- a/docs/references/inclusive-language.md
+++ b/docs/references/inclusive-language.md
@@ -1,0 +1,34 @@
+# Inclusive language reference
+
+The fleet uses precise, neutral terms over historical metaphors that imply hierarchy or exclusion. The substitutes are not euphemisms — they're more _accurate_ (a list of allowed values genuinely is an "allowlist"; "whitelist" is a metaphor that hides what the list does).
+
+## Substitution table
+
+| Replace                          | With                                                |
+| -------------------------------- | --------------------------------------------------- |
+| `whitelist` / `whitelisted`      | `allowlist` / `allowed` / `allowlisted`             |
+| `blacklist` / `blacklisted`      | `denylist` / `denied` / `blocklisted` / `blocked`   |
+| `master` (branch, process, copy) | `main` (branch); `primary` / `controller` (process) |
+| `slave`                          | `replica`, `worker`, `secondary`, `follower`        |
+| `grandfathered`                  | `legacy`, `pre-existing`, `exempted`                |
+| `sanity check`                   | `quick check`, `confidence check`, `smoke test`     |
+| `dummy` (placeholder)            | `placeholder`, `stub`                               |
+
+## Where to apply
+
+- **Code**: identifiers, comments, string literals.
+- **Docs**: READMEs, CLAUDE.md, markdown.
+- **Config**: YAML, JSON.
+- **History**: commit messages, PR titles/descriptions.
+- **CI logs** you control.
+
+## Two narrow exceptions
+
+The legacy term must remain only when changing it would break something external:
+
+- **Third-party APIs / upstream code**: when interfacing with an external API field literally named `whitelist`, keep the field name; rename your local variable. Example: `const allowedDomains = response.whitelist`.
+- **Vendored upstream sources**: don't rewrite vendored code under `vendor/**`, `upstream/**`, or `**/fixtures/**`. Patch around it if needed.
+
+## When to fix
+
+When you encounter a legacy term during unrelated work, fix it inline — don't defer.

--- a/docs/references/sorting.md
+++ b/docs/references/sorting.md
@@ -1,0 +1,16 @@
+# Sorting reference
+
+Sort lists alphanumerically (literal byte order, ASCII before letters).
+
+## Where to sort
+
+- **Config lists** — `permissions.allow` / `permissions.deny` in `.claude/settings.json`, `external-tools.json` checksum keys, allowlists in workflow YAML.
+- **Object key entries** — keys in plain JSON config + return-shape literals + internal-state objects. (Exception: `__proto__: null` always comes first, ahead of any data keys.)
+- **Import specifiers** — sort named imports inside a single statement: `import { encrypt, randomDataKey, wrapKey } from './crypto.mts'`. `import type` follows the same rule. Statement _order_ (`node:` → external → local → types) is separate from specifier order _within_ a statement.
+- **Method / function placement** — within a module, sort top-level functions alphabetically. Convention: private functions (lowercase / un-exported) sort first, exported functions second. The `export` keyword is the divider.
+- **Array literals** — when the array is a config list, allowlist, or set-like collection. Position-bearing arrays (e.g. `argv`, anything where index matters semantically) keep their meaningful order.
+- **`Set` constructor arguments** — `new Set([...])` and `new SafeSet([...])` literals. The runtime is order-insensitive, so source order is alphanumeric. Same rationale as Array literals: predictable diffs, no merge conflicts on insertions.
+
+## Default
+
+When in doubt, sort. The cost of a sorted list that didn't need to be is approximately zero; the cost of an unsorted list that did need to be is a merge conflict.

--- a/scripts/socket-repo-template-emit-schema.mts
+++ b/scripts/socket-repo-template-emit-schema.mts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Emit `socket-repo-template-schema.json` from the
+ * TypeBox source.
+ *
+ * Run via `pnpm run socket-repo-template:emit-schema` from a fleet
+ * repo (the worktree where TypeBox is installed). Mirrors the xport
+ * emit pattern.
+ */
+
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { spawn } from '@socketsecurity/lib/spawn'
+import { getDefaultLogger } from '@socketsecurity/lib/logger'
+
+import { SocketRepoTemplateConfigSchema } from './socket-repo-template-schema.mts'
+
+const logger = getDefaultLogger()
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, '..')
+const outPath = path.join(rootDir, 'socket-repo-template-schema.json')
+
+const enriched = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://github.com/SocketDev/socket-repo-template-schema.json',
+  title: 'socket-repo-template per-repo config',
+  ...SocketRepoTemplateConfigSchema,
+}
+
+writeFileSync(outPath, JSON.stringify(enriched, null, 2) + '\n', 'utf8')
+
+// Run oxfmt on the output so the file matches what oxfmt would
+// produce. Without this, `pnpm run check --all` (which runs oxfmt
+// over the tree) would flag the emitted schema as drifted on every
+// repo that re-emits it. The schema is in IDENTICAL_FILES, so the
+// formatted form is the byte-canonical form fleet-wide.
+await spawn('pnpm', ['exec', 'oxfmt', outPath], {
+  cwd: rootDir,
+  stdio: 'inherit',
+})
+
+logger.success(`wrote ${path.relative(rootDir, outPath)}`)

--- a/scripts/socket-repo-template-schema.mts
+++ b/scripts/socket-repo-template-schema.mts
@@ -1,0 +1,263 @@
+/**
+ * @fileoverview TypeBox schema for `.socket-repo-template.json` — the
+ * per-fleet-repo config consumed by `sync-scaffolding`.
+ *
+ * Each fleet repo (socket-lib, socket-cli, ultrathink, …) ships a
+ * `.socket-repo-template.json` at its root declaring its kind +
+ * any per-repo opt-ins. The runner reads it to decide which optional
+ * files the repo is expected to ship and which it must not ship.
+ *
+ * Source-of-truth flow:
+ *   - This TypeBox source → `Static<typeof SocketRepoTemplateConfigSchema>`
+ *     for typed reads in the runner.
+ *   - `socket-repo-template-emit-schema.mts` writes
+ *     `socket-repo-template-schema.json` (draft 2020-12) at the repo root.
+ *   - `.socket-repo-template.json` references the JSON Schema via its
+ *     `$schema` field for IDE autocompletion.
+ *
+ * Byte-identical across the fleet via sync-scaffolding's IDENTICAL_FILES.
+ */
+
+import { Type, type Static } from '@sinclair/typebox'
+
+// ---------------------------------------------------------------------------
+// Kind enum.
+// ---------------------------------------------------------------------------
+
+const KindSchema = Type.Union(
+  [
+    Type.Literal('single-package'),
+    Type.Literal('mono-no-native'),
+    Type.Literal('consumer'),
+    Type.Literal('producer'),
+    Type.Literal('both'),
+    Type.Literal('lang-ports'),
+  ],
+  {
+    description:
+      'Fleet repo category. Determines which opt-in files the repo must ship and which it must not. See README.md "Fleet kinds" for the table.',
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Hooks block — git hook variant selection.
+// ---------------------------------------------------------------------------
+
+const HooksSchema = Type.Object(
+  {
+    enablePrePush: Type.Optional(
+      Type.Boolean({
+        description:
+          'Wire `.husky/pre-push` → `.git-hooks/pre-push.mts`. Mandatory security gate; default true.',
+      }),
+    ),
+    enableCommitMsg: Type.Optional(
+      Type.Boolean({
+        description:
+          'Wire `.husky/commit-msg` → `.git-hooks/commit-msg.mts`. Strips AI attribution; default true.',
+      }),
+    ),
+    enablePreCommit: Type.Optional(
+      Type.Boolean({
+        description:
+          'Wire `.husky/pre-commit` → `.git-hooks/pre-commit.mts`. Lint + secret scan on staged files; default true.',
+      }),
+    ),
+    preCommitVariant: Type.Optional(
+      Type.Union([Type.Literal('lint-only'), Type.Literal('lint-test')], {
+        description:
+          '`lint-only` runs format + secret scan; `lint-test` adds vitest on touched packages. Default `lint-test`.',
+      }),
+    ),
+  },
+  { description: 'Git-hook opt-ins.' },
+)
+
+// ---------------------------------------------------------------------------
+// Scripts block — package.json script declarations.
+// ---------------------------------------------------------------------------
+
+const ScriptsSchema = Type.Object(
+  {
+    required: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          'Override REQUIRED_SCRIPTS from manifest.mts. Usually omitted — the fleet default applies.',
+      }),
+    ),
+    optional: Type.Optional(
+      Type.Record(Type.String(), Type.Boolean(), {
+        description:
+          'Per-script opt-in map keyed by script name. `true` = repo ships this RECOMMENDED script; `false` = explicit opt-out.',
+      }),
+    ),
+    bodyExempt: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          'Script names whose body is allowed to drift from the canonical form (e.g. socket-lib runs a richer test runner than the standard `node scripts/test.mts`). Each entry is the script name only.',
+      }),
+    ),
+  },
+  { description: 'package.json script tracking overrides.' },
+)
+
+// ---------------------------------------------------------------------------
+// Lint block — oxlint profile selection.
+// ---------------------------------------------------------------------------
+
+const LintSchema = Type.Object(
+  {
+    profile: Type.Optional(
+      Type.Union([Type.Literal('standard'), Type.Literal('rich')], {
+        description:
+          '`standard` requires the fleet plugin set (import + typescript + unicorn). `rich` opts into a wider set; check the runner for the exact basenames currently exempted.',
+      }),
+    ),
+  },
+  { description: 'oxlint profile.' },
+)
+
+// ---------------------------------------------------------------------------
+// Workflows block — GitHub Actions opt-ins.
+// ---------------------------------------------------------------------------
+
+const WorkflowsSchema = Type.Object(
+  {
+    ci: Type.Optional(
+      Type.Boolean({ description: 'Ship `.github/workflows/ci.yml`.' }),
+    ),
+    weeklyUpdate: Type.Optional(
+      Type.Boolean({
+        description: 'Ship `.github/workflows/weekly-update.yml`.',
+      }),
+    ),
+    provenance: Type.Optional(
+      Type.Boolean({
+        description:
+          'Repo publishes with npm provenance (OIDC). Hint for setup helpers; not enforced by the checker today.',
+      }),
+    ),
+    requirePinnedFullSha: Type.Optional(
+      Type.Boolean({
+        description:
+          'Enforce 40-char SHA pins on every `uses:` ref. Defaults to true; an opt-out is reserved for special cases (e.g. workflow-dispatch test rigs) and currently has no consumer.',
+      }),
+    ),
+  },
+  { description: 'CI workflow opt-ins.' },
+)
+
+// ---------------------------------------------------------------------------
+// Claude block — opt-in agents/skills/commands.
+// ---------------------------------------------------------------------------
+
+const ClaudeSchema = Type.Object(
+  {
+    includeSecurityScanSkill: Type.Optional(
+      Type.Boolean({
+        description: 'Ship `.claude/skills/security-scan/SKILL.md`.',
+      }),
+    ),
+    includeSharedSkills: Type.Optional(
+      Type.Boolean({
+        description:
+          'Ship `.claude/skills/_shared/*` — env-check, path-guard-rule, report-format, security-tools, verify-build.',
+      }),
+    ),
+    includeUpdatingSkill: Type.Optional(
+      Type.Boolean({
+        description:
+          'Ship the dependency-update skill. Reserved — no consumer wired today.',
+      }),
+    ),
+  },
+  { description: 'Claude Code opt-ins.' },
+)
+
+// ---------------------------------------------------------------------------
+// Workspace block — pnpm-workspace.yaml derived settings.
+// ---------------------------------------------------------------------------
+
+const WorkspaceSchema = Type.Object(
+  {
+    allowBuilds: Type.Optional(
+      Type.Record(Type.String(), Type.Boolean(), {
+        description:
+          'pnpm `onlyBuiltDependencies` allowlist. Map a package name to true/false to grant/deny build scripts.',
+      }),
+    ),
+    blockExoticSubdeps: Type.Optional(
+      Type.Boolean({
+        description:
+          'Refuse transitive git/tarball subdeps (direct git deps still allowed). Required true; the field exists so a repo can document the intent locally.',
+      }),
+    ),
+    minimumReleaseAge: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        description:
+          'Soak window in minutes before installing freshly-published packages. Fleet default 10080 (= 7 days).',
+      }),
+    ),
+    minimumReleaseAgeExclude: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          'Scopes / package patterns exempt from the soak window. Socket-owned scopes typically listed here.',
+      }),
+    ),
+    resolutionMode: Type.Optional(
+      Type.Union([Type.Literal('highest'), Type.Literal('lowest-direct')], {
+        description: 'pnpm `resolutionMode`. Fleet default `highest`.',
+      }),
+    ),
+    trustPolicy: Type.Optional(
+      Type.Union([Type.Literal('no-downgrade'), Type.Literal('match-spec')], {
+        description: 'pnpm `trustPolicy`. Fleet default `no-downgrade`.',
+      }),
+    ),
+  },
+  {
+    description:
+      'pnpm-workspace.yaml setting hints. The runner reads from the YAML; this block exists for repos that prefer to declare intent in JSON.',
+  },
+)
+
+// ---------------------------------------------------------------------------
+// Top-level config.
+// ---------------------------------------------------------------------------
+
+export const SocketRepoTemplateConfigSchema = Type.Object(
+  {
+    $schema: Type.Optional(
+      Type.String({
+        description:
+          'JSON Schema reference for editor autocompletion. Conventionally `./socket-repo-template-schema.json`.',
+      }),
+    ),
+    schemaVersion: Type.Literal(1, {
+      description:
+        'Schema version. Bump on breaking changes; readers gate on it.',
+    }),
+    repoName: Type.String({
+      pattern: '^[a-z0-9][a-z0-9-]*$',
+      description:
+        'Canonical repo basename (e.g. `socket-lib`, `ultrathink`). Used for kind-independent exemptions like the oxlint `socket-lib` carve-out.',
+    }),
+    kind: KindSchema,
+    hooks: Type.Optional(HooksSchema),
+    scripts: Type.Optional(ScriptsSchema),
+    lint: Type.Optional(LintSchema),
+    workflows: Type.Optional(WorkflowsSchema),
+    claude: Type.Optional(ClaudeSchema),
+    workspace: Type.Optional(WorkspaceSchema),
+  },
+  {
+    description:
+      'Per-repo socket-repo-template config. Lives at the fleet repo root as `.socket-repo-template.json`.',
+  },
+)
+
+export type SocketRepoTemplateConfig = Static<
+  typeof SocketRepoTemplateConfigSchema
+>
+export type Kind = Static<typeof KindSchema>

--- a/socket-repo-template-schema.json
+++ b/socket-repo-template-schema.json
@@ -1,0 +1,229 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/SocketDev/socket-repo-template-schema.json",
+  "title": "socket-repo-template per-repo config",
+  "description": "Per-repo socket-repo-template config. Lives at the fleet repo root as `.socket-repo-template.json`.",
+  "type": "object",
+  "required": ["schemaVersion", "repoName", "kind"],
+  "properties": {
+    "$schema": {
+      "description": "JSON Schema reference for editor autocompletion. Conventionally `./socket-repo-template-schema.json`.",
+      "type": "string"
+    },
+    "schemaVersion": {
+      "description": "Schema version. Bump on breaking changes; readers gate on it.",
+      "const": 1,
+      "type": "number"
+    },
+    "repoName": {
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "description": "Canonical repo basename (e.g. `socket-lib`, `ultrathink`). Used for kind-independent exemptions like the oxlint `socket-lib` carve-out.",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Fleet repo category. Determines which opt-in files the repo must ship and which it must not. See README.md \"Fleet kinds\" for the table.",
+      "anyOf": [
+        {
+          "const": "single-package",
+          "type": "string"
+        },
+        {
+          "const": "mono-no-native",
+          "type": "string"
+        },
+        {
+          "const": "consumer",
+          "type": "string"
+        },
+        {
+          "const": "producer",
+          "type": "string"
+        },
+        {
+          "const": "both",
+          "type": "string"
+        },
+        {
+          "const": "lang-ports",
+          "type": "string"
+        }
+      ]
+    },
+    "hooks": {
+      "description": "Git-hook opt-ins.",
+      "type": "object",
+      "properties": {
+        "enablePrePush": {
+          "description": "Wire `.husky/pre-push` → `.git-hooks/pre-push.mts`. Mandatory security gate; default true.",
+          "type": "boolean"
+        },
+        "enableCommitMsg": {
+          "description": "Wire `.husky/commit-msg` → `.git-hooks/commit-msg.mts`. Strips AI attribution; default true.",
+          "type": "boolean"
+        },
+        "enablePreCommit": {
+          "description": "Wire `.husky/pre-commit` → `.git-hooks/pre-commit.mts`. Lint + secret scan on staged files; default true.",
+          "type": "boolean"
+        },
+        "preCommitVariant": {
+          "description": "`lint-only` runs format + secret scan; `lint-test` adds vitest on touched packages. Default `lint-test`.",
+          "anyOf": [
+            {
+              "const": "lint-only",
+              "type": "string"
+            },
+            {
+              "const": "lint-test",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "scripts": {
+      "description": "package.json script tracking overrides.",
+      "type": "object",
+      "properties": {
+        "required": {
+          "description": "Override REQUIRED_SCRIPTS from manifest.mts. Usually omitted — the fleet default applies.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "optional": {
+          "description": "Per-script opt-in map keyed by script name. `true` = repo ships this RECOMMENDED script; `false` = explicit opt-out.",
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "type": "boolean"
+            }
+          }
+        },
+        "bodyExempt": {
+          "description": "Script names whose body is allowed to drift from the canonical form (e.g. socket-lib runs a richer test runner than the standard `node scripts/test.mts`). Each entry is the script name only.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "lint": {
+      "description": "oxlint profile.",
+      "type": "object",
+      "properties": {
+        "profile": {
+          "description": "`standard` requires the fleet plugin set (import + typescript + unicorn). `rich` opts into a wider set; check the runner for the exact basenames currently exempted.",
+          "anyOf": [
+            {
+              "const": "standard",
+              "type": "string"
+            },
+            {
+              "const": "rich",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "workflows": {
+      "description": "CI workflow opt-ins.",
+      "type": "object",
+      "properties": {
+        "ci": {
+          "description": "Ship `.github/workflows/ci.yml`.",
+          "type": "boolean"
+        },
+        "weeklyUpdate": {
+          "description": "Ship `.github/workflows/weekly-update.yml`.",
+          "type": "boolean"
+        },
+        "provenance": {
+          "description": "Repo publishes with npm provenance (OIDC). Hint for setup helpers; not enforced by the checker today.",
+          "type": "boolean"
+        },
+        "requirePinnedFullSha": {
+          "description": "Enforce 40-char SHA pins on every `uses:` ref. Defaults to true; an opt-out is reserved for special cases (e.g. workflow-dispatch test rigs) and currently has no consumer.",
+          "type": "boolean"
+        }
+      }
+    },
+    "claude": {
+      "description": "Claude Code opt-ins.",
+      "type": "object",
+      "properties": {
+        "includeSecurityScanSkill": {
+          "description": "Ship `.claude/skills/security-scan/SKILL.md`.",
+          "type": "boolean"
+        },
+        "includeSharedSkills": {
+          "description": "Ship `.claude/skills/_shared/*` — env-check, path-guard-rule, report-format, security-tools, verify-build.",
+          "type": "boolean"
+        },
+        "includeUpdatingSkill": {
+          "description": "Ship the dependency-update skill. Reserved — no consumer wired today.",
+          "type": "boolean"
+        }
+      }
+    },
+    "workspace": {
+      "description": "pnpm-workspace.yaml setting hints. The runner reads from the YAML; this block exists for repos that prefer to declare intent in JSON.",
+      "type": "object",
+      "properties": {
+        "allowBuilds": {
+          "description": "pnpm `onlyBuiltDependencies` allowlist. Map a package name to true/false to grant/deny build scripts.",
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "type": "boolean"
+            }
+          }
+        },
+        "blockExoticSubdeps": {
+          "description": "Refuse transitive git/tarball subdeps (direct git deps still allowed). Required true; the field exists so a repo can document the intent locally.",
+          "type": "boolean"
+        },
+        "minimumReleaseAge": {
+          "minimum": 0,
+          "description": "Soak window in minutes before installing freshly-published packages. Fleet default 10080 (= 7 days).",
+          "type": "integer"
+        },
+        "minimumReleaseAgeExclude": {
+          "description": "Scopes / package patterns exempt from the soak window. Socket-owned scopes typically listed here.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "resolutionMode": {
+          "description": "pnpm `resolutionMode`. Fleet default `highest`.",
+          "anyOf": [
+            {
+              "const": "highest",
+              "type": "string"
+            },
+            {
+              "const": "lowest-direct",
+              "type": "string"
+            }
+          ]
+        },
+        "trustPolicy": {
+          "description": "pnpm `trustPolicy`. Fleet default `no-downgrade`.",
+          "anyOf": [
+            {
+              "const": "no-downgrade",
+              "type": "string"
+            },
+            {
+              "const": "match-spec",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **CLAUDE.md restructure** — fleet-canonical layout (public-surface hygiene, parallel-session safeguards, code style, tooling) with sdk-specific extensions.
- **New skills** — `programmatic-claude-lockdown`, `promise-race-pitfall`.
- **Skills updated** — `path-guard` (SKILL.md drift; `_shared/path-guard-rule.md`).
- **Doctrine refs** — `docs/references/inclusive-language.md`, `docs/references/sorting.md`.
- **Repo-template integration** — `.socket-repo-template.json` + schema tooling.

## Scope

Skills + CLAUDE.md slice split out of #630.

Companion splits: hooks + cascade+deps. After all three land, #630 closes.

## Test plan

- [ ] CLAUDE.md renders cleanly
- [ ] No content lost vs #630 — files content-identical