### PR TITLE
fix(fleet): gitignore the generated oxlint plugin bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,13 @@ pnpm-debug.log
 # refresh; keep it out of tracking until the fleet gitignore block covers it. ───
 /.claude/hooks/fleet/_dist/
 
+# ─── repo-local: fleet oxlint plugin bundle build output (generated-outputs-are-untracked).
+# The rolldown-inlined bundle rebuilt by scripts/fleet/build-oxlint-bundle.mts from
+# .config/fleet/oxlint-plugin/; shipped in the GitHub-release bundle, never committed.
+# It lands on disk during setup/check, so oxfmt's format walk would otherwise gate
+# the bundler output. Keep it untracked until the fleet gitignore block covers it. ───
+/.config/fleet/oxlint-plugin.mjs
+
 # Derived cross-harness rule adapters — generated per-repo, per-platform by
 # the multi-agent scaffolding (setup / init / sync) script from .claude/skills/
 # and CLAUDE.md, never committed. A tracked symlink checks out as a plain


### PR DESCRIPTION
## What

Add `.config/fleet/oxlint-plugin.mjs` to `.gitignore` so the generated oxlint plugin bundle is no longer picked up by oxfmt's format walk.

## Why

`.config/fleet/oxlint-plugin.mjs` is a rolldown build artifact — it's rebuilt during setup/check by `scripts/fleet/build-oxlint-bundle.mts` from the `.config/fleet/oxlint-plugin/` sources. Its own builder doc says it's "gitignored ... shipped in the release bundle, never committed." But nothing actually ignored it.

So once the bundle lands on disk (which happens during setup/check), oxfmt walks the ~544 KB bundler output, reports it as unformatted, and fails `pnpm run check --all`'s format pass. That reddens `main`'s ⚡ CI 🔎 Check job and the same job on PR #661.

The fix mirrors how the sibling generated fleet bundles are handled (the hook `_dispatch/*.cjs` artifacts): ignore the generated output. oxfmt respects `.gitignore`, so the format walk drops from 223 to 222 files and passes.

The entry lives in the repo-local `generated-outputs-are-untracked` section, right after the existing `/.claude/hooks/fleet/_dist/` entry — outside the cascade-managed fleet block, so it's cascade-safe.

<details>
<summary>Why not just run the formatter on the file?</summary>

The bundle is generated and untracked. CI rebuilds it fresh via rolldown every run (emitting the same unformatted output), then format-checks it — so reformatting-and-committing can't hold: the file isn't tracked, and it's regenerated on the next build. Ignoring it is the correct fix. Confirmed locally: format the file → check passes → rebuild bundle → check fails again.
</details>

<details>
<summary>Why gitignore and not .prettierignore?</summary>

Both make the format check pass. Gitignore is the right call: it matches the builder's own "gitignored, never committed" contract and the untrack-the-generated-bundle pattern already used for the hook bundles. A `.prettierignore`-only entry would leave the bundle untracked-but-not-ignored, which is the messier state.
</details>

## Testing

- `pnpm run format:check` → 222 files, all pass (was 223 files + fail with the bundle present on disk).
- Guard checks pass: `gitignore-is-single-file`, `generated-globs-are-consistent`, `ignored-files-are-untracked`.
- Config-only change — no unit test.

Do not merge yet.