### PR TITLE
fix(fleet): disable typescript/no-unnecessary-type-assertion

### DIFF
--- a/.config/fleet/oxlintrc.json
+++ b/.config/fleet/oxlintrc.json
@@ -180,6 +180,7 @@
         "allowDestructuring": true
       }
     ],
+    "typescript/no-unnecessary-type-assertion": "off",
     "typescript/no-useless-empty-export": "error",
     "typescript/no-wrapper-object-types": "error",
     "typescript/prefer-as-const": "error",


### PR DESCRIPTION
Disables `typescript/no-unnecessary-type-assertion` fleet-wide (cascaded from our shared template). One line in `.config/fleet/oxlintrc.json`.

## Why
The type-aware pass (`--type-aware` / tsgolint) builds `scripts/**/*.mts` a DEFAULT program because it can't discover a strict tsconfig above `scripts/`. That drops `noUncheckedIndexedAccess`, so the fleet-mandated cached-for-loop `arr[i]!` assertions (required by `socket/prefer-cached-for-loop` + `noUncheckedIndexedAccess`) read as unnecessary and red 🔎 Check. Adding tsconfig files was ruled out, so the rule is turned off.

## Source
The canonical entry landed in our shared fleet template config; this mirrors it. `checkOxlintRuleActivations` would otherwise cascade the same "off" entry on the next sync.