### PR TITLE
fix(types): type listOrganizations result as a keyed map, not an array

### DIFF
--- a/scripts/repo/generate-strict-types-emit.mts
+++ b/scripts/repo/generate-strict-types-emit.mts
@@ -129,11 +129,15 @@ export type StreamFullScanOptions = {
 
 /**
  * Strict type for organizations list result.
+ *
+ * The GET /organizations endpoint returns \`organizations\` as a map keyed by
+ * organization id (OpenAPI \`additionalProperties\`), not an array. Type it as a
+ * Record so consumers iterate with Object.values()/Object.entries().
  */
 export type OrganizationsResult = {
   cause?: undefined | undefined
   data: {
-    organizations: OrganizationItem[]
+    organizations: Record<string, OrganizationItem>
   }
   error?: undefined | undefined
   status: number

--- a/src/socket-sdk-class.mts
+++ b/src/socket-sdk-class.mts
@@ -5166,9 +5166,10 @@ export class SocketSdk {
    *   const result = await sdk.listOrganizations()
    *
    *   if (result.success) {
-   *     result.data.organizations.forEach(org => {
-   *       console.log(org.name, org.slug) // Guaranteed fields
-   *     })
+   *   // `organizations` is a map keyed by org id, so iterate its values.
+   *   Object.values(result.data.organizations).forEach(org => {
+   *   console.log(org.name, org.slug) // Guaranteed fields
+   *   })
    *   }
    *   ```
    *

--- a/src/types-strict.mts
+++ b/src/types-strict.mts
@@ -318,11 +318,15 @@ export type StreamFullScanOptions = {
 
 /**
  * Strict type for organizations list result.
+ *
+ * The GET /organizations endpoint returns `organizations` as a map keyed by
+ * organization id (OpenAPI `additionalProperties`), not an array. Type it as a
+ * Record so consumers iterate with Object.values()/Object.entries().
  */
 export type OrganizationsResult = {
   cause?: undefined
   data: {
-    organizations: OrganizationItem[]
+    organizations: Record<string, OrganizationItem>
   }
   error?: undefined
   status: number

--- a/test/repo/unit/types-strict.test.mts
+++ b/test/repo/unit/types-strict.test.mts
@@ -15,6 +15,7 @@ import type {
   FullScanItem,
   FullScanListResult,
   FullScanResult,
+  OrganizationItem,
   OrganizationsResult,
 } from '../../../src/types-strict.mts'
 import { safeDeleteSync } from '@socketsecurity/lib-stable/fs/safe'
@@ -243,21 +244,25 @@ describe.sequential('Strict Types - v3.0', () => {
 
   describe('OrganizationsResult', () => {
     it('should have guaranteed organization fields', async () => {
+      // GET /v0/organizations returns `organizations` as a map keyed by org
+      // id (OpenAPI `additionalProperties`), not an array.
       const mockResponse = {
-        organizations: [
-          {
+        organizations: {
+          'org-1': {
             id: 'org-1',
             name: 'Test Org',
             slug: 'test-org',
+            // `plan` is an open-ended string; the API returns arbitrary plan
+            // identifiers beyond a fixed set.
             plan: 'pro',
           },
-          {
+          'org-2': {
             id: 'org-2',
             name: 'Another Org',
             slug: 'another-org',
-            plan: 'free',
+            plan: 'enterprise-custom-2025',
           },
-        ],
+        },
       }
 
       nock('https://api.socket.dev')
@@ -272,9 +277,14 @@ describe.sequential('Strict Types - v3.0', () => {
       if (result.success) {
         const typedResult: OrganizationsResult = result
 
-        expect(typedResult.data.organizations).toHaveLength(2)
+        // The result is a keyed map, so iterate its values (as consumers must).
+        const orgs = Object.values(typedResult.data.organizations)
+        expect(orgs).toHaveLength(2)
+        expect(Object.keys(typedResult.data.organizations)).toEqual([
+          'org-1',
+          'org-2',
+        ])
 
-        const orgs = typedResult.data.organizations
         for (let i = 0, { length } = orgs; i < length; i += 1) {
           const org = orgs[i]!
           // All fields should be present and correctly typed
@@ -284,16 +294,40 @@ describe.sequential('Strict Types - v3.0', () => {
           expect(typeof org.plan).toBe('string')
         }
 
-        // Specific value checks
-        const firstOrg = typedResult.data.organizations[0]
-        const secondOrg = typedResult.data.organizations[1]
+        // Lookup by key, plus specific value checks.
+        const firstOrg = typedResult.data.organizations['org-1']
+        const secondOrg = typedResult.data.organizations['org-2']
         expect(firstOrg).toBeDefined()
         expect(secondOrg).toBeDefined()
         if (firstOrg && secondOrg) {
           expect(firstOrg.name).toBe('Test Org')
           expect(secondOrg.slug).toBe('another-org')
+          // Open-ended plan strings are accepted, not just a fixed union.
+          expect(secondOrg.plan).toBe('enterprise-custom-2025')
         }
       }
+    })
+
+    it('types organizations as a keyed map and plan as an open string', () => {
+      // Compile-time lock: `organizations` must be a Record keyed by org id,
+      // and `plan` must accept any string (not a narrow union). This block is
+      // validated by the type checker, not at runtime.
+      const orgs: OrganizationsResult['data']['organizations'] = {
+        'org-1': {
+          id: 'org-1',
+          name: 'Test Org',
+          slug: 'test-org',
+          plan: 'some-brand-new-plan',
+        },
+      }
+
+      // Index access returns an OrganizationItem (map shape, not array).
+      const org: OrganizationItem | undefined = orgs['org-1']
+      expect(org?.plan).toBe('some-brand-new-plan')
+
+      // `plan` is `string`: an arbitrary runtime string is assignable.
+      const plan: OrganizationItem['plan'] = String(Date.now())
+      expect(typeof plan).toBe('string')
     })
   })
 


### PR DESCRIPTION
## What

Fixes two result-type correctness bugs on the `listOrganizations()` result type, surfaced during the socket-vscode SDK migration (task #65).

1. **`organizations` is a map, not an array.** `GET /v0/organizations` returns `organizations` as an object keyed by org id (OpenAPI `additionalProperties`). `OrganizationsResult` declared it as `OrganizationItem[]`. socket-vscode had to reach for `Object.values()` to stay correct. The strict type is now `Record<string, OrganizationItem>`.
2. **`plan` is an open-ended string.** The task flagged the org plan field as a narrow 3-value union that needed widening. In the current `main` it is already typed as `string` (both the OpenAPI schema and the generated types agree), so there was nothing to widen. New tests lock that in so a future narrowing regresses loudly.

## Breaking change

This is a breaking **type** change: consumers that treated `organizations` as an array will now get type errors. The runtime was always a map, so anything relying on the array type was already broken at runtime — this change makes the compiler catch it.

## Fixed at the generator source

`src/types-strict.mts` is auto-generated from the OpenAPI spec. The fix was made in the generator's emit template (`scripts/repo/generate-strict-types-emit.mts`) and the generated artifact regenerated to match — not hand-patched downstream.

<details>
<summary>Root cause, before/after, and how types are produced</summary>

### How the types are produced

`src/types-strict.mts` carries a banner: `AUTO-GENERATED from OpenAPI definitions using AST parsing - DO NOT EDIT MANUALLY`. It is produced by `scripts/repo/generate-strict-types.mts`, which reads the local `openapi.json`, runs `openapi-typescript` over it, and emits strict wrapper types via the template functions in `scripts/repo/generate-strict-types-emit.mts`. The `OrganizationsResult` wrapper is emitted by `generateWrapperTypes()` in that emit file, so that is the correct place to fix it.

### OpenAPI source of truth

The `/organizations` GET 200 schema:

```jsonc
"organizations": {
  "type": "object",
  "additionalProperties": { /* org object with id, name, image, plan, slug */ }
}
```

`additionalProperties` means a map keyed by org id — a `Record`, not an array. `plan` is `{ "type": "string" }`, i.e. already open-ended.

### Before / after (strict type)

```diff
 export type OrganizationsResult = {
   cause?: undefined
   data: {
-    organizations: OrganizationItem[]
+    organizations: Record<string, OrganizationItem>
   }
   error?: undefined
   status: number
   success: true
 }
```

The generator has a separate, pre-existing path bug (the fleet migration moved these scripts into `scripts/repo/`, but `getRootPath()` still only walks up one level, so it looks for `openapi.json` under `scripts/` instead of the repo root). Running the generator in-place therefore fails today. I validated the template change by running the generator against the OpenAPI at the path it expects, confirmed it emits `Record<string, OrganizationItem>`, then applied that exact change to the committed generated artifact preserving its existing format. Fixing the generator's path resolution is out of scope for this change.

### JSDoc example

The `listOrganizations()` doc example iterated with `result.data.organizations.forEach(...)`, which is invalid for a map. Updated to `Object.values(result.data.organizations).forEach(...)`.
</details>

## Tests

- Rewrote the `OrganizationsResult` runtime test in `test/repo/unit/types-strict.test.mts` to mock the real map shape (previously it mocked an array — which never occurs at runtime), asserting map-keyed access via `Object.values()` / `Object.keys()` and key lookup.
- Added a compile-time (type-level) test locking `organizations` to a keyed `Record` and `plan` to an open `string` (not a narrow union). The block is validated by the type checker.

## Verification

All run on Node 24.18.0:

| Command | Result |
| --- | --- |
| `pnpm run type` (`tsgo --noEmit`) | pass |
| `pnpm run lint` (oxlint + oxfmt) | pass |
| `vitest run .../types-strict.test.mts` | 7 passed |
| pre-commit hook (staged lint + tests) | 10 passed |
| `pnpm run build` | pass (dist declarations show the `Record` shape) |
