### PR TITLE
fix(scripts): resolve repo root in strict-types generator after scripts/repo move

### DIFF
--- a/scripts/utils/path-helpers.mts
+++ b/scripts/utils/path-helpers.mts
@@ -1,6 +1,7 @@
 /**
  * @file Path utility helpers for script operations.
  */
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -12,8 +13,30 @@ export function getDirname(importMetaUrl: string): string {
 }
 
 /**
- * Get root directory path from current script location.
+ * Get root directory path from the calling script's location by walking up to
+ * the nearest `package.json`-bearing ancestor (the repo root).
+ * Depth-independent so a script moving between directories (e.g. the
+ * scripts-into-`scripts/repo/` fleet migration) doesn't break path resolution —
+ * a fixed `..` count would. Mirrors `resolveRepoRoot()` in
+ * `scripts/fleet/paths.mts`.
+ *
+ * @throws If no `package.json` ancestor exists (= not inside a repo).
  */
 export function getRootPath(importMetaUrl: string): string {
-  return path.join(getDirname(importMetaUrl), '..')
+  let cur = getDirname(importMetaUrl)
+  const { root } = path.parse(cur)
+  while (cur && cur !== root) {
+    if (existsSync(path.join(cur, 'package.json'))) {
+      return cur
+    }
+    const parent = path.dirname(cur)
+    if (parent === cur) {
+      break
+    }
+    cur = parent
+  }
+  throw new Error(
+    `Could not resolve repo root from ${fileURLToPath(importMetaUrl)} ` +
+      '(no ancestor has package.json).',
+  )
 }


### PR DESCRIPTION
## What

`getRootPath()` in `scripts/utils/path-helpers.mts` walked up a fixed single directory level. That resolved the repo root correctly when the scripts lived one level deep, but the fleet migration moved them into `scripts/repo/` (and `scripts/utils/`), so the strict-types generator then looked for `openapi.json` under `scripts/` and could not run.

## Fix

Walk up to the nearest `package.json`-bearing ancestor instead of a fixed depth, mirroring `resolveRepoRoot()` in `scripts/fleet/paths.mts`. This is depth-independent, so it stays correct across future directory moves and fixes every sibling script under `scripts/repo/` that shares this helper.

<details>
<summary>Context</summary>

Found while landing PR #667 (the org-list/plan type fixes): the strict-types generator is auto-generated from `openapi.json`, but it could not be run straight because of this path bug — the fix there had to be validated by pointing the generator at the spec's expected path manually. This makes the generator runnable from its real location again.
</details>

## Verification

Scoped to the one helper (+25/-2). CI runs typecheck, lint, and the generated-types-are-current check.