### PR TITLE
fix(publish): land bumps via PR + squash auto-merge; guard build reproducibility

### DIFF
--- a/scripts/fleet/cargo-publish.mts
+++ b/scripts/fleet/cargo-publish.mts
@@ -194,11 +194,12 @@ async function main(): Promise<void> {
     }
     throw e
   }
-  // The publish SUCCEEDED — fast-forward main to the bump commit (same SHA) and
-  // remove the release branch. Deliberately OUTSIDE the try: a failed
-  // fast-forward (main moved / branch-protected) must NOT discard the branch,
-  // since the crate version is already permanently published — leave it for
-  // manual reconcile and fail loud.
+  // The publish SUCCEEDED — land the bump on main by opening a PR from the
+  // release branch and enabling squash auto-merge (a branch-protected main
+  // rejects a direct ref push from the release App with 422). Deliberately
+  // OUTSIDE the try: a failed promote must NOT discard the branch, since the
+  // crate version is already permanently published — leave the branch (its PR
+  // keeps the bump reachable) and fail loud.
   if (bumpResult) {
     await promoteReleaseBranch(bumpResult.releaseBranch, bumpResult.sha)
   }

--- a/scripts/fleet/lib/github-pull-requests.mts
+++ b/scripts/fleet/lib/github-pull-requests.mts
@@ -1,0 +1,207 @@
+/**
+ * @file GitHub pull-request REST + GraphQL helpers — open a PR, enable
+ *   squash auto-merge, and (fallback) merge it now. The publish pipeline's
+ *   branch-based promote uses these instead of a direct fast-forward PATCH of
+ *   `main`: a branch-protected `main` that requires "changes must be made
+ *   through a pull request" rejects the direct ref PATCH with 422, so the
+ *   release App (which is NOT on main's push-bypass allowlist) can never
+ *   advance `main` by hand. Routing the promote through a PR + auto-merge works
+ *   WITHIN branch protection — no bypass needed. `createPullRequest` is
+ *   idempotent (a leftover open PR from a re-run is reused, not duplicated).
+ *   `enablePullRequestAutoMerge` is GraphQL (the only auto-merge surface);
+ *   `mergePullRequest` is the REST fallback for the "already mergeable, nothing
+ *   to wait on" case where GitHub refuses to enable auto-merge. All calls go
+ *   over node:http (httpJson), so nock intercepts them in tests.
+ */
+
+import {
+  httpJson,
+  HttpResponseError,
+} from '@socketsecurity/lib-stable/http-request'
+
+const DEFAULT_API_URL = 'https://api.github.com'
+
+// GitHub's auto-merge-enable mutation refuses when the PR is ALREADY in a
+// mergeable ("clean") state with nothing to wait on — there is no pending
+// requirement to merge-when-satisfied against. This is the sentinel the
+// mutation returns in that case; the caller falls back to an immediate merge.
+const AUTO_MERGE_CLEAN_STATUS = 'Pull request is in clean status'
+
+export interface PullRequestApiConfig {
+  // Override the API origin (GitHub Enterprise / tests). Defaults to api.github.com.
+  readonly apiUrl?: string | undefined
+  // Repo in "owner/name" form.
+  readonly repo: string
+  // GitHub token with pull_requests:write (the release App token in CI).
+  readonly token: string
+}
+
+export interface CreatePullRequestConfig extends PullRequestApiConfig {
+  // Target branch the PR merges into (e.g. 'main').
+  readonly base: string
+  // PR body (markdown).
+  readonly body: string
+  // Source branch holding the commit(s) to merge (e.g. 'npm-publish-v1.4.3').
+  readonly head: string
+  // PR title.
+  readonly title: string
+}
+
+export interface OpenPullRequest {
+  // The PR's GraphQL node id — required to enable auto-merge.
+  readonly nodeId: string
+  // The PR number (for the REST merge fallback + logging).
+  readonly number: number
+}
+
+export interface EnableAutoMergeConfig extends PullRequestApiConfig {
+  // The squash commit subject. Pinned to the bump subject so the reconcile
+  // anchor (`chore: bump version to <version>`) survives the squash.
+  readonly commitHeadline: string
+  // The PR's GraphQL node id (from createPullRequest).
+  readonly pullRequestId: string
+}
+
+export interface MergePullRequestConfig extends PullRequestApiConfig {
+  // The squash commit subject (same value as EnableAutoMergeConfig.commitHeadline).
+  readonly commitTitle: string
+  // The PR number (from createPullRequest).
+  readonly number: number
+}
+
+function restHeaders(token: string): Record<string, string> {
+  return {
+    accept: 'application/vnd.github+json',
+    authorization: `Bearer ${token}`,
+    'content-type': 'application/json',
+    'x-github-api-version': '2022-11-28',
+  }
+}
+
+/**
+ * Open a PR from `head` into `base`. Idempotent: a re-run whose branch already
+ * has an open PR (create returns 422 "A pull request already exists") reuses
+ * that PR instead of failing, so a retried promote never duplicates it. Returns
+ * the PR number + GraphQL node id. Throws `HttpResponseError` on any other
+ * non-2xx.
+ */
+export async function createPullRequest(
+  config: CreatePullRequestConfig,
+): Promise<OpenPullRequest> {
+  const cfg = { __proto__: null, ...config } as CreatePullRequestConfig
+  const apiUrl = cfg.apiUrl ?? DEFAULT_API_URL
+  try {
+    const pr = await httpJson<{ node_id: string; number: number }>(
+      `${apiUrl}/repos/${cfg.repo}/pulls`,
+      {
+        body: JSON.stringify({
+          base: cfg.base,
+          body: cfg.body,
+          head: cfg.head,
+          maintainer_can_modify: false,
+          title: cfg.title,
+        }),
+        headers: restHeaders(cfg.token),
+        method: 'POST',
+        timeout: 30_000,
+      },
+    )
+    return { nodeId: pr.node_id, number: pr.number }
+  } catch (e) {
+    const status =
+      e instanceof HttpResponseError ? e.response.status : undefined
+    if (status !== 422) {
+      throw e
+    }
+    // A PR for this head already exists (a re-run) — find + reuse it.
+    const owner = cfg.repo.slice(0, cfg.repo.indexOf('/'))
+    const existing = await httpJson<Array<{ node_id: string; number: number }>>(
+      `${apiUrl}/repos/${cfg.repo}/pulls?head=${encodeURIComponent(
+        `${owner}:${cfg.head}`,
+      )}&base=${encodeURIComponent(cfg.base)}&state=open`,
+      {
+        headers: restHeaders(cfg.token),
+        method: 'GET',
+        timeout: 30_000,
+      },
+    )
+    const found = existing[0]
+    if (!found) {
+      throw e
+    }
+    return { nodeId: found.node_id, number: found.number }
+  }
+}
+
+/**
+ * Enable SQUASH auto-merge on a PR, so GitHub merges it the moment its branch-
+ * protection requirements clear (required review, checks) — no push-bypass and
+ * no local wait. `commitHeadline` pins the squash commit subject so the bump
+ * subject (the reconcile anchor) survives. Auto-merge is a GraphQL-only
+ * surface. Returns `false` (never throws) when GitHub refuses because the PR is
+ * already in a clean/mergeable state with nothing to wait on — the caller then
+ * merges immediately via `mergePullRequest`. Throws on any other GraphQL
+ * error.
+ */
+export async function enablePullRequestAutoMerge(
+  config: EnableAutoMergeConfig,
+): Promise<boolean> {
+  const cfg = { __proto__: null, ...config } as EnableAutoMergeConfig
+  const apiUrl = cfg.apiUrl ?? DEFAULT_API_URL
+  const graphqlUrl = `${apiUrl}/graphql`
+  const query = `mutation($id: ID!, $headline: String!) {
+    enablePullRequestAutoMerge(input: {
+      pullRequestId: $id,
+      mergeMethod: SQUASH,
+      commitHeadline: $headline
+    }) { clientMutationId }
+  }`
+  const result = await httpJson<{
+    errors?: Array<{ message: string }> | undefined
+  }>(graphqlUrl, {
+    body: JSON.stringify({
+      query,
+      variables: { headline: cfg.commitHeadline, id: cfg.pullRequestId },
+    }),
+    headers: restHeaders(cfg.token),
+    method: 'POST',
+    timeout: 30_000,
+  })
+  const errors = result.errors
+  if (errors && errors.length) {
+    // "Clean status" is expected for a PR with no pending requirement to wait
+    // on — signal the caller to merge now rather than treat it as a failure.
+    if (errors.some(err => err.message.includes(AUTO_MERGE_CLEAN_STATUS))) {
+      return false
+    }
+    throw new Error(
+      `[github-pull-requests] enablePullRequestAutoMerge failed: ${errors
+        .map(err => err.message)
+        .join('; ')}`,
+    )
+  }
+  return true
+}
+
+/**
+ * Merge a PR NOW via REST, squashing to a single commit whose subject is
+ * `commitTitle` (the bump subject). The immediate-merge fallback for when
+ * auto-merge can't be enabled (nothing to wait on). Throws `HttpResponseError`
+ * on a non-2xx (e.g. a required review the App can't satisfy — a real block the
+ * operator must resolve, surfaced loud).
+ */
+export async function mergePullRequest(
+  config: MergePullRequestConfig,
+): Promise<void> {
+  const cfg = { __proto__: null, ...config } as MergePullRequestConfig
+  const apiUrl = cfg.apiUrl ?? DEFAULT_API_URL
+  await httpJson(`${apiUrl}/repos/${cfg.repo}/pulls/${cfg.number}/merge`, {
+    body: JSON.stringify({
+      commit_title: cfg.commitTitle,
+      merge_method: 'squash',
+    }),
+    headers: restHeaders(cfg.token),
+    method: 'PUT',
+    timeout: 30_000,
+  })
+}

--- a/scripts/fleet/npm-publish.mts
+++ b/scripts/fleet/npm-publish.mts
@@ -304,12 +304,13 @@ async function main(): Promise<void> {
     }
     throw e
   }
-  // The publish SUCCEEDED — fast-forward main to the bump commit (same SHA) and
-  // remove the release branch. This is deliberately OUTSIDE the try: if the
-  // fast-forward fails (main moved mid-publish, or a branch-protected main the
-  // App can't advance), the throw must NOT discard the branch — the version is
-  // already published, so promoteReleaseBranch leaves the branch intact for
-  // manual reconcile and fails loud.
+  // The publish SUCCEEDED — land the bump on main by opening a PR from the
+  // release branch and enabling squash auto-merge (a branch-protected main
+  // rejects a direct ref push from the release App with 422). This is
+  // deliberately OUTSIDE the try: if the promote fails, the throw must NOT
+  // discard the branch — the version is already published, so
+  // promoteReleaseBranch leaves the branch intact (its PR keeps the bump
+  // reachable) and fails loud.
   if (bumpResult) {
     await promoteReleaseBranch(bumpResult.releaseBranch, bumpResult.sha)
   }

--- a/scripts/fleet/publish-infra/release-branch.mts
+++ b/scripts/fleet/publish-infra/release-branch.mts
@@ -1,11 +1,14 @@
 /**
  * @file Registry-agnostic release-branch orchestration for the CI publish path.
  *   The version bump commits land on a throwaway `<channel>-publish-v<version>`
- *   branch instead of directly on `main`; only a SUCCESSFUL publish
- *   fast-forwards `main` to that branch tip (same SHA) then deletes it, and a
- *   FAILED publish deletes the branch so `main` is never touched — no version
- *   creep, and safe when `main` is branch-protected. Shared by the npm + cargo
- *   bump tiers (both accumulate their commit(s) on the branch this opens).
+ *   branch instead of directly on `main`; only a SUCCESSFUL publish lands that
+ *   branch on `main` — through a PULL REQUEST with squash auto-merge, so a
+ *   branch-protected `main` (which rejects a direct ref push from the release
+ *   App with 422 "changes must be made through a pull request") is advanced
+ *   without a push-bypass. A FAILED publish deletes the branch so `main` is
+ *   never touched — no version creep, and safe when `main` is branch-protected.
+ *   Shared by the npm + cargo bump tiers (both accumulate their commit(s) on
+ *   the branch this opens).
  */
 
 import process from 'node:process'
@@ -17,6 +20,11 @@ import {
   deleteBranchRef,
   updateBranchRef,
 } from '../lib/github-git-refs.mts'
+import {
+  createPullRequest,
+  enablePullRequestAutoMerge,
+  mergePullRequest,
+} from '../lib/github-pull-requests.mts'
 import { logger } from './shared.mts'
 
 export interface ReleaseEnv {
@@ -33,6 +41,9 @@ export interface ReleaseBranch {
   readonly branch: string
   // The resolved CI release environment.
   readonly env: ReleaseEnv
+  // The version this branch bumps to — pins the promote PR's squash subject to
+  // `chore: bump version to <version>` (the reconcile anchor) and titles the PR.
+  readonly version: string
 }
 
 export interface BumpResult {
@@ -116,32 +127,75 @@ export async function openReleaseBranch(config: {
   logger.log(
     `[release-branch] opened ${branch} at ${cfg.parentSha.slice(0, 7)}.`,
   )
-  return { branch, env }
+  return { branch, env, version: cfg.version }
 }
 
 /**
- * Publish succeeded: fast-forward the dispatch branch to the release branch tip
- * (`tipSha` — the exact commit that was built + published, same SHA), then
- * delete the release branch. Fast-forward-only: if the dispatch branch moved
- * mid-publish the advance is a non-fast-forward and `updateBranchRef` throws
- * loud, leaving the branch for manual reconcile rather than rewriting history.
+ * Publish succeeded: land the release branch's bump commit on the dispatch
+ * branch through a PULL REQUEST, not a direct ref push. A branch-protected
+ * `main` that requires "changes must be made through a pull request" rejects a
+ * direct fast-forward PATCH with 422 (the release App is NOT on main's
+ * push-bypass allowlist), which used to force a maintainer to hand-land every
+ * bump. Opening a PR from the release branch and enabling squash auto-merge
+ * works WITHIN branch protection — no bypass needed.
+ *
+ * The squash commit subject is pinned to `chore: bump version to <version>`
+ * (the same subject the bump commit carries) so the reconcile anchor survives
+ * the squash — `findPublishedBaseSha` / the version-flip anchor lookups keep
+ * resolving the landed bump. Branch protection typically permits only a squash
+ * merge (linear history), so the release App's exact app-signed commit SHA is
+ * not preserved verbatim; the squashed commit is created under the release App
+ * and GitHub-signed (Verified), carrying byte-identical bump content.
+ *
+ * `tipSha` is the built + published commit (informational — used for the log
+ * line; the PR head branch already points at it). When auto-merge cannot be
+ * enabled because the PR is already mergeable with nothing to wait on, the
+ * merge is performed immediately. The release branch is auto-deleted on merge
+ * (repos set `delete_branch_on_merge`); it is deliberately NOT deleted here,
+ * since deleting it before the merge would close the PR.
  */
 export async function promoteReleaseBranch(
   releaseBranch: ReleaseBranch,
   tipSha: string,
 ): Promise<void> {
-  const { branch, env } = releaseBranch
-  await updateBranchRef({
-    branch: env.mainBranch,
-    force: false,
+  const { branch, env, version } = releaseBranch
+  const commitSubject = `chore: bump version to ${version}`
+  const pr = await createPullRequest({
+    base: env.mainBranch,
+    body:
+      `Automated version bump to \`${version}\` from the publish pipeline, ` +
+      `landed via PR because \`${env.mainBranch}\` requires changes go through ` +
+      `a pull request. The version is already live on the registry; this ` +
+      `advances \`${env.mainBranch}\` to the bump commit (${tipSha.slice(0, 7)}).`,
+    head: branch,
     repo: env.repo,
-    sha: tipSha,
+    title: commitSubject,
     token: env.token,
   })
-  await deleteBranchRef({ branch, repo: env.repo, token: env.token })
+  const queued = await enablePullRequestAutoMerge({
+    commitHeadline: commitSubject,
+    pullRequestId: pr.nodeId,
+    repo: env.repo,
+    token: env.token,
+  })
+  if (queued) {
+    logger.success(
+      `[release-branch] opened PR #${pr.number} (${branch} → ${env.mainBranch}) ` +
+        `and enabled squash auto-merge; ${env.mainBranch} advances when its ` +
+        `branch-protection requirements clear.`,
+    )
+    return
+  }
+  // Nothing to wait on — merge now.
+  await mergePullRequest({
+    commitTitle: commitSubject,
+    number: pr.number,
+    repo: env.repo,
+    token: env.token,
+  })
   logger.success(
-    `[release-branch] fast-forwarded ${env.mainBranch} to ${tipSha.slice(0, 7)} ` +
-      `and removed ${branch}.`,
+    `[release-branch] opened PR #${pr.number} (${branch} → ${env.mainBranch}) ` +
+      `and squash-merged it into ${env.mainBranch}.`,
   )
 }
 

--- a/test/repo/unit/build-reproducible.test.mts
+++ b/test/repo/unit/build-reproducible.test.mts
@@ -1,0 +1,90 @@
+/**
+ * @file Determinism guard for the rolldown bundle. The publish-pipeline
+ *   `--reconcile` path cuts a version's tag + GH release only when a LOCAL
+ *   re-pack byte-matches the published npm tarball, so the bundle MUST be
+ *   byte-reproducible run-to-run — otherwise a re-pack diverges and reconcile
+ *   refuses. This builds each rolldown config twice into isolated temp dirs and
+ *   asserts the emitted bytes (including the content-hashed chunk names) are
+ *   identical between runs. A future config/toolchain change that reintroduces
+ *   non-determinism (a timestamp banner, an unstable chunk hash, order churn)
+ *   fails here instead of silently breaking the next reconcile.
+ *
+ * @vitest-environment node
+ */
+
+import { createHash } from 'node:crypto'
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { rolldown } from 'rolldown'
+import { afterAll, describe, expect, it } from 'vitest'
+
+import { buildConfig } from '../../../.config/repo/rolldown.config.mts'
+import { browserBuildConfig } from '../../../.config/repo/rolldown.browser.config.mts'
+
+import type { RolldownOptions } from 'rolldown'
+
+const tempDirs: string[] = []
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+// name → sha256 of every emitted file (recursive), so a comparison captures
+// content AND the content-hashed chunk file names.
+function hashOutputDir(dir: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  const walk = (current: string, prefix: string): void => {
+    for (const entry of readdirSync(current).sort()) {
+      const full = path.join(current, entry)
+      const rel = prefix ? `${prefix}/${entry}` : entry
+      if (statSync(full).isDirectory()) {
+        walk(full, rel)
+      } else {
+        out[rel] = createHash('sha256').update(readFileSync(full)).digest('hex')
+      }
+    }
+  }
+  walk(dir, '')
+  return out
+}
+
+async function buildInto(
+  config: RolldownOptions & { output: { dir?: string | undefined } },
+): Promise<Record<string, string>> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'sdk-repro-'))
+  tempDirs.push(dir)
+  const { output, ...inputOptions } = config
+  const bundle = await rolldown(inputOptions)
+  try {
+    await bundle.write({ ...output, dir })
+  } finally {
+    await bundle.close()
+  }
+  return hashOutputDir(dir)
+}
+
+describe('bundle is byte-reproducible', () => {
+  it('produces byte-identical node output across two builds', async () => {
+    const first = await buildInto(buildConfig)
+    const second = await buildInto(buildConfig)
+    expect(Object.keys(first).length).toBeGreaterThan(0)
+    expect(second).toEqual(first)
+  }, 60_000)
+
+  it('produces byte-identical browser output across two builds', async () => {
+    const first = await buildInto(browserBuildConfig)
+    const second = await buildInto(browserBuildConfig)
+    expect(Object.keys(first).length).toBeGreaterThan(0)
+    expect(second).toEqual(first)
+  }, 60_000)
+})

--- a/test/repo/unit/github-pull-requests.test.mts
+++ b/test/repo/unit/github-pull-requests.test.mts
@@ -1,0 +1,218 @@
+/**
+ * @file Tests for the GitHub pull-request helpers + the release-branch promote
+ *   that routes a branch-protected `main` bump through a PR + squash auto-merge
+ *   instead of a direct fast-forward ref push (which a protected main rejects
+ *   with 422). All GitHub calls are mocked with nock over node:http.
+ *
+ * @vitest-environment node
+ */
+
+import nock from 'nock'
+import { describe, expect, it } from 'vitest'
+
+import {
+  createPullRequest,
+  enablePullRequestAutoMerge,
+  mergePullRequest,
+} from '../../../scripts/fleet/lib/github-pull-requests.mts'
+import { promoteReleaseBranch } from '../../../scripts/fleet/publish-infra/release-branch.mts'
+import {
+  isCoverageMode,
+  setupTestEnvironment,
+} from '../../utils/environment.mts'
+
+import type { ReleaseBranch } from '../../../scripts/fleet/publish-infra/release-branch.mts'
+
+const API = 'https://api.github.com'
+const REPO = 'SocketDev/socket-sdk-js'
+
+// Nock static replies are skipped in coverage mode (forks pool) — same guard
+// the SDK's nock suites use.
+const describeGh = isCoverageMode ? describe.skip : describe
+
+function releaseBranch(): ReleaseBranch {
+  return {
+    branch: 'npm-publish-v1.4.3',
+    env: {
+      mainBranch: 'main',
+      repo: REPO,
+      token: 'release-app-token',
+    },
+    version: '1.4.3',
+  }
+}
+
+// oxlint-disable-next-line socket/require-vitest-globals-import -- describeGh aliases the imported describe (describe.skip in coverage mode), not a global.
+describeGh('github-pull-requests', () => {
+  setupTestEnvironment()
+
+  describe('createPullRequest', () => {
+    it('opens a PR and returns its number + node id', async () => {
+      nock(API)
+        .post(`/repos/${REPO}/pulls`, body => {
+          expect(body.base).toBe('main')
+          expect(body.head).toBe('npm-publish-v1.4.3')
+          expect(body.title).toBe('chore: bump version to 1.4.3')
+          return true
+        })
+        .reply(201, { node_id: 'PR_node_1', number: 42 })
+
+      const pr = await createPullRequest({
+        base: 'main',
+        body: 'bump',
+        head: 'npm-publish-v1.4.3',
+        repo: REPO,
+        title: 'chore: bump version to 1.4.3',
+        token: 't',
+      })
+
+      expect(pr).toEqual({ nodeId: 'PR_node_1', number: 42 })
+    })
+
+    it('reuses the existing open PR when create returns 422', async () => {
+      nock(API)
+        .post(`/repos/${REPO}/pulls`)
+        .reply(422, { message: 'A pull request already exists for ...' })
+      nock(API)
+        .get(`/repos/${REPO}/pulls`)
+        .query({
+          base: 'main',
+          head: 'SocketDev:npm-publish-v1.4.3',
+          state: 'open',
+        })
+        .reply(200, [{ node_id: 'PR_node_existing', number: 7 }])
+
+      const pr = await createPullRequest({
+        base: 'main',
+        body: 'bump',
+        head: 'npm-publish-v1.4.3',
+        repo: REPO,
+        title: 'chore: bump version to 1.4.3',
+        token: 't',
+      })
+
+      expect(pr).toEqual({ nodeId: 'PR_node_existing', number: 7 })
+    })
+  })
+
+  describe('enablePullRequestAutoMerge', () => {
+    it('returns true when auto-merge is enabled', async () => {
+      nock(API)
+        .post('/graphql', body => {
+          expect(body.variables.id).toBe('PR_node_1')
+          expect(body.variables.headline).toBe('chore: bump version to 1.4.3')
+          expect(body.query).toContain('mergeMethod: SQUASH')
+          return true
+        })
+        .reply(200, { data: { enablePullRequestAutoMerge: {} } })
+
+      const queued = await enablePullRequestAutoMerge({
+        commitHeadline: 'chore: bump version to 1.4.3',
+        pullRequestId: 'PR_node_1',
+        repo: REPO,
+        token: 't',
+      })
+
+      expect(queued).toBe(true)
+    })
+
+    it('returns false (not throw) when the PR is already in clean status', async () => {
+      nock(API)
+        .post('/graphql')
+        .reply(200, {
+          errors: [{ message: 'Pull request is in clean status' }],
+        })
+
+      const queued = await enablePullRequestAutoMerge({
+        commitHeadline: 'chore: bump version to 1.4.3',
+        pullRequestId: 'PR_node_1',
+        repo: REPO,
+        token: 't',
+      })
+
+      expect(queued).toBe(false)
+    })
+
+    it('throws on any other GraphQL error', async () => {
+      nock(API)
+        .post('/graphql')
+        .reply(200, { errors: [{ message: 'Resource not accessible' }] })
+
+      await expect(
+        enablePullRequestAutoMerge({
+          commitHeadline: 'chore: bump version to 1.4.3',
+          pullRequestId: 'PR_node_1',
+          repo: REPO,
+          token: 't',
+        }),
+      ).rejects.toThrow(/Resource not accessible/)
+    })
+  })
+
+  describe('mergePullRequest', () => {
+    it('squash-merges the PR with the bump subject as the commit title', async () => {
+      nock(API)
+        .put(`/repos/${REPO}/pulls/42/merge`, body => {
+          expect(body.merge_method).toBe('squash')
+          expect(body.commit_title).toBe('chore: bump version to 1.4.3')
+          return true
+        })
+        .reply(200, { merged: true })
+
+      await expect(
+        mergePullRequest({
+          commitTitle: 'chore: bump version to 1.4.3',
+          number: 42,
+          repo: REPO,
+          token: 't',
+        }),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('promoteReleaseBranch', () => {
+    it('opens a PR and enables squash auto-merge (no direct ref push)', async () => {
+      nock(API)
+        .post(`/repos/${REPO}/pulls`, body => {
+          expect(body.title).toBe('chore: bump version to 1.4.3')
+          return true
+        })
+        .reply(201, { node_id: 'PR_node_1', number: 42 })
+      nock(API)
+        .post('/graphql', body => {
+          expect(body.variables.headline).toBe('chore: bump version to 1.4.3')
+          return true
+        })
+        .reply(200, { data: { enablePullRequestAutoMerge: {} } })
+
+      await expect(
+        promoteReleaseBranch(releaseBranch(), 'abc1234def'),
+      ).resolves.toBeUndefined()
+      // Both interceptors consumed → no direct PATCH of refs/heads/main.
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('merges immediately when auto-merge cannot be enabled (clean status)', async () => {
+      nock(API)
+        .post(`/repos/${REPO}/pulls`)
+        .reply(201, { node_id: 'PR_node_1', number: 42 })
+      nock(API)
+        .post('/graphql')
+        .reply(200, {
+          errors: [{ message: 'Pull request is in clean status' }],
+        })
+      nock(API)
+        .put(`/repos/${REPO}/pulls/42/merge`, body => {
+          expect(body.merge_method).toBe('squash')
+          expect(body.commit_title).toBe('chore: bump version to 1.4.3')
+          return true
+        })
+        .reply(200, { merged: true })
+
+      await expect(
+        promoteReleaseBranch(releaseBranch(), 'abc1234def'),
+      ).resolves.toBeUndefined()
+      expect(nock.isDone()).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
Fixes two release-tooling gaps found during the 4.1.0 / 4.1.1 releases.

## #75 — release App can't fast-forward main (every release needed a hand-land)

**Problem.** On a successful publish, the pipeline advances `main` to the release-app-signed bump commit. It did this with a direct fast-forward ref `PATCH` (`updateBranchRef`), which a branch-protected `main` rejects with `422 "Changes must be made through a pull request"` — the release App (`SOCKET_RELEASE_CLIENT_ID`) is not on main's push-bypass allowlist. So every 4.1.0 / 4.1.1 release required a maintainer to hand-land the bump.

**Fix (in the tooling, not a settings change).** `promoteReleaseBranch` now opens a PR from the release branch and enables **squash auto-merge**, so the bump lands *within* branch protection — no bypass needed. The squash commit subject is pinned to `chore: bump version to <version>` so the reconcile anchor survives the squash.

<details>
<summary>How it works + the provenance tradeoff</summary>

- New `scripts/fleet/lib/github-pull-requests.mts`:
  - `createPullRequest` — idempotent (a re-run whose branch already has an open PR reuses it on `422` instead of duplicating).
  - `enablePullRequestAutoMerge` — GraphQL (the only auto-merge surface); returns `false` (doesn't throw) on GitHub's "clean status" refusal so the caller can merge immediately.
  - `mergePullRequest` — REST fallback for the "already mergeable, nothing to wait on" case.
  - All calls go over `node:http` (`httpJson`), so `nock` intercepts them in tests.
- `ReleaseBranch` now carries `version`, used to pin the squash subject and title the PR.
- **Provenance.** The repo's branch protection allows **squash-merge only** (`allow_merge_commit: false`, `allow_rebase_merge: false`), so the release App's exact app-signed commit SHA can't be preserved verbatim under any PR-based flow. The squashed commit is created under the release App and GitHub-signed (Verified), carrying byte-identical bump content and the same subject. Preserving the exact SHA would require enabling merge/rebase merges + adding the App to a push-bypass — i.e. the settings change this fix avoids.
</details>

<details>
<summary>Prerequisites / decisions needed before this fully automates</summary>

1. **Auto-merge is already enabled** on the repo (`allow_auto_merge: true`) — no action needed.
2. **Required review.** `main` requires 1 approving review. Auto-merge will *queue* the PR but only completes once that requirement clears. For hands-free releases the release App needs to satisfy/bypass the PR-review requirement (a ruleset bypass actor for the App). Without it, the worst case is a maintainer clicking "approve" — still strictly better than today's manual hand-land. This is the one piece a workflow change can't remove on its own; flagging it as a decision.
3. **App permission.** The release App token must have `pull_requests: write` (it already has `contents: write` for the bump commit).
4. **Cascade ownership.** `scripts/fleet/*` are cascade-owned mirror files (the pre-commit reports them as "cascade payload — gated at the template source"). To persist fleet-wide, this change should also land in the wheelhouse template; otherwise the next cascade reverts it here.
</details>

## #76 — build reproducibility for `--reconcile`

**Investigated the claimed non-determinism — the build is already byte-reproducible.** The premise (non-deterministic rolldown bundling) does not hold:

- Two consecutive local `pnpm run build` runs produce **byte-identical** `dist/` (all 23 files, including the content-hashed `rolldown-runtime-*.js` chunk).
- A fresh local build's `dist/` is **byte-identical to the published v4.1.1 npm tarball's `dist/`** — reproducible across NODE_ENV and across absolute checkout paths (local `/tmp/...` vs CI `/home/runner/...`).
- The only non-`dist/` differences vs the published tarball (README badge URL, pruned `preinstall` script) are exactly what the reconcile's own pack brackets (`withPinnedReadme` + `withPrunedPackManifest`) apply, so the reconcile re-pack matches too.

**So the historical reconcile refusals weren't bundler non-determinism** — they were operational: the local re-pack compared against a `dist/` that wasn't a fresh rebuild from the content commit with the frozen lockfile. The CI `release-reconcile.yml` workflow already does the right thing (checkout content commit → `pnpm install --frozen-lockfile` → `pnpm run build` → `--reconcile`), so the production reconcile path is already sound.

Rather than fabricate a config change that just restates already-correct defaults, this adds a **determinism guard test** that locks in the reproducibility contract.

<details>
<summary>The guard test</summary>

`test/repo/unit/build-reproducible.test.mts` builds each rolldown config (node + browser) twice into isolated temp dirs and asserts the emitted bytes and content-hashed file names are identical between runs. A future config/toolchain change that reintroduces non-determinism (timestamp banner, unstable chunk hash, order churn) fails here instead of silently breaking the next reconcile.
</details>

## Verification

- `pnpm run type` — clean.
- `pnpm run lint` — clean.
- New tests pass: `github-pull-requests.test.mts` (8), `build-reproducible.test.mts` (2).
- Two-build byte-identical `dist/` proven (`diff -rq` exit 0); fresh build == published v4.1.1 tarball `dist/` (`diff -rq` exit 0).
- Full suite: the only failures are pre-existing and environment-specific — `utils.test.mts` asserts the checkout dir is named `socket-sdk-js`, but this worktree is `/tmp/sdk-release-tooling`. Unrelated to this change.

Do not merge — release-critical, for review.
