### PR TITLE
Run HTTP and retry tests during coverage

### DIFF
--- a/test/repo/unit/socket-sdk-json-parsing-errors.test.mts
+++ b/test/repo/unit/socket-sdk-json-parsing-errors.test.mts
@@ -4,7 +4,7 @@
 import nock from 'nock'
 import { describe, expect, it } from 'vitest'
 
-import { isCoverageMode, setupTestClient } from '../../utils/environment.mts'
+import { setupTestClient } from '../../utils/environment.mts'
 
 import type { SocketSdkGenericResult } from '../../../src/index.mts'
 
@@ -30,66 +30,57 @@ describe('SocketSdk - Branch Coverage Tests', () => {
       }
     })
 
-    it.skipIf(isCoverageMode)(
-      'should handle empty responseText slice branch',
-      async () => {
-        // Create a scenario where responseText would be empty after slicing
-        nock('https://api.socket.dev')
-          .get('/v0/empty-response-test')
-          .reply(200, '')
+    it('should handle empty responseText slice branch', async () => {
+      // Create a scenario where responseText would be empty after slicing
+      nock('https://api.socket.dev')
+        .get('/v0/empty-response-test')
+        .reply(200, '')
 
-        const result = (await getClient().getApi('empty-response-test', {
-          responseType: 'json',
-          throws: false,
-        })) as SocketSdkGenericResult<unknown>
+      const result = (await getClient().getApi('empty-response-test', {
+        responseType: 'json',
+        throws: false,
+      })) as SocketSdkGenericResult<unknown>
 
-        // Empty response should actually parse as {} and succeed
-        expect(result.success).toBe(true)
-      },
-    )
+      // Empty response should actually parse as {} and succeed
+      expect(result.success).toBe(true)
+    })
   })
 
   describe('API error handling branches', () => {
-    it.skipIf(isCoverageMode)(
-      'should handle ResponseError in getApi with throws: false',
-      async () => {
-        // Mock a ResponseError (HTTP error response) for getApi
-        nock('https://api.socket.dev')
-          .get('/v0/getapi-error-test')
-          .reply(404, { error: 'Not Found', message: 'Resource not found' })
+    it('should handle ResponseError in getApi with throws: false', async () => {
+      // Mock a ResponseError (HTTP error response) for getApi
+      nock('https://api.socket.dev')
+        .get('/v0/getapi-error-test')
+        .reply(404, { error: 'Not Found', message: 'Resource not found' })
 
-        const result = (await getClient().getApi('getapi-error-test', {
-          responseType: 'json',
-          throws: false,
-        })) as SocketSdkGenericResult<unknown>
+      const result = (await getClient().getApi('getapi-error-test', {
+        responseType: 'json',
+        throws: false,
+      })) as SocketSdkGenericResult<unknown>
 
-        expect(result.success).toBe(false)
-        if (!result.success) {
-          expect(result.status).toBe(404)
-        }
-      },
-    )
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.status).toBe(404)
+      }
+    })
 
-    it.skipIf(isCoverageMode)(
-      'should handle ResponseError in sendApi with throws: false',
-      async () => {
-        // Mock a ResponseError (HTTP error response)
-        nock('https://api.socket.dev')
-          .post('/v0/response-error-test')
-          .reply(400, { error: 'Bad Request', message: 'Invalid data' })
+    it('should handle ResponseError in sendApi with throws: false', async () => {
+      // Mock a ResponseError (HTTP error response)
+      nock('https://api.socket.dev')
+        .post('/v0/response-error-test')
+        .reply(400, { error: 'Bad Request', message: 'Invalid data' })
 
-        const result = (await getClient().sendApi('response-error-test', {
-          throws: false,
-          method: 'POST',
-          body: { test: 'data' },
-        })) as SocketSdkGenericResult<unknown>
+      const result = (await getClient().sendApi('response-error-test', {
+        throws: false,
+        method: 'POST',
+        body: { test: 'data' },
+      })) as SocketSdkGenericResult<unknown>
 
-        expect(result.success).toBe(false)
-        if (!result.success) {
-          expect(result.status).toBe(400)
-        }
-      },
-    )
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.status).toBe(400)
+      }
+    })
   })
 
   describe('Edge cases for complete branch coverage', () => {
@@ -112,44 +103,38 @@ describe('SocketSdk - Branch Coverage Tests', () => {
       expect(result.success).toBe(false)
     })
 
-    it.skipIf(isCoverageMode)(
-      'should detect 502 Bad Gateway in response body',
-      async () => {
-        nock('https://api.socket.dev')
-          .get('/v0/502-test')
-          .reply(200, '502 Bad Gateway')
+    it('should detect 502 Bad Gateway in response body', async () => {
+      nock('https://api.socket.dev')
+        .get('/v0/502-test')
+        .reply(200, '502 Bad Gateway')
 
-        const result = (await getClient().getApi('502-test', {
-          responseType: 'json',
-          throws: false,
-        })) as SocketSdkGenericResult<unknown>
+      const result = (await getClient().getApi('502-test', {
+        responseType: 'json',
+        throws: false,
+      })) as SocketSdkGenericResult<unknown>
 
-        expect(result.success).toBe(false)
-        if (!result.success) {
-          expect(result.error).toBe('Server returned invalid JSON')
-          expect(result.cause).toContain('502 Bad Gateway')
-        }
-      },
-    )
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBe('Server returned invalid JSON')
+        expect(result.cause).toContain('502 Bad Gateway')
+      }
+    })
 
-    it.skipIf(isCoverageMode)(
-      'should detect 503 Service in response body',
-      async () => {
-        nock('https://api.socket.dev')
-          .get('/v0/503-test')
-          .reply(200, '503 Service Unavailable')
+    it('should detect 503 Service in response body', async () => {
+      nock('https://api.socket.dev')
+        .get('/v0/503-test')
+        .reply(200, '503 Service Unavailable')
 
-        const result = (await getClient().getApi('503-test', {
-          responseType: 'json',
-          throws: false,
-        })) as SocketSdkGenericResult<unknown>
+      const result = (await getClient().getApi('503-test', {
+        responseType: 'json',
+        throws: false,
+      })) as SocketSdkGenericResult<unknown>
 
-        expect(result.success).toBe(false)
-        if (!result.success) {
-          expect(result.error).toBe('Server returned invalid JSON')
-          expect(result.cause).toContain('503 Service')
-        }
-      },
-    )
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBe('Server returned invalid JSON')
+        expect(result.cause).toContain('503 Service')
+      }
+    })
   })
 })

--- a/test/repo/unit/socket-sdk-optional-config.test.mts
+++ b/test/repo/unit/socket-sdk-optional-config.test.mts
@@ -12,11 +12,11 @@ import nock from 'nock'
 import { describe, expect, it } from 'vitest'
 
 import { SocketSdk } from '../../../src/index.mts'
-import { isCoverageMode, setupTestClient } from '../../utils/environment.mts'
+import { setupTestClient } from '../../utils/environment.mts'
 
 import type { SocketSdkGenericResult } from '../../../src/index.mts'
 
-describe.skipIf(isCoverageMode)('SocketSdk - Optional Configuration', () => {
+describe('SocketSdk - Optional Configuration', () => {
   const getClient = setupTestClient('test-token', { retries: 0 })
 
   describe('Cache configuration', () => {

--- a/test/repo/unit/socket-sdk-retry-rate-limit.test.mts
+++ b/test/repo/unit/socket-sdk-retry-rate-limit.test.mts
@@ -5,24 +5,13 @@
  * @vitest-environment node
  */
 
-// Run these tests in isolated mode to prevent nock state bleeding.
-// Nock callback replies are incompatible with forks pool (used in coverage mode),
-// so tests using static replies are skipped when COVERAGE=true.
 import nock from 'nock'
 import { describe, expect, it } from 'vitest'
 
 import { SocketSdk } from '../../../src/index.mts'
-import {
-  isCoverageMode,
-  setupTestEnvironment,
-} from '../../utils/environment.mts'
+import { setupTestEnvironment } from '../../utils/environment.mts'
 
-// Nock HTTP mocking is incompatible with vitest forks pool (used by isolated config).
-// The retry logic is still tested in the main thread pool config.
-const describeRetry = isCoverageMode ? describe.skip : describe
-
-// oxlint-disable-next-line socket/require-vitest-globals-import -- describeRetry is a local const aliasing the imported describe (describe.skip in coverage mode), not a vitest global.
-describeRetry('SocketSdk - Retry Logic', () => {
+describe('SocketSdk - Retry Logic', () => {
   setupTestEnvironment()
 
   describe('Rate Limit Retry with Retry-After Header', () => {

--- a/test/repo/unit/socket-sdk-retry.test.mts
+++ b/test/repo/unit/socket-sdk-retry.test.mts
@@ -6,24 +6,13 @@
  * @vitest-environment node
  */
 
-// Run these tests in isolated mode to prevent nock state bleeding.
-// Nock callback replies are incompatible with forks pool (used in coverage mode),
-// so tests using static replies are skipped when COVERAGE=true.
 import nock from 'nock'
 import { describe, expect, it } from 'vitest'
 
 import { SocketSdk } from '../../../src/index.mts'
-import {
-  isCoverageMode,
-  setupTestEnvironment,
-} from '../../utils/environment.mts'
+import { setupTestEnvironment } from '../../utils/environment.mts'
 
-// Nock HTTP mocking is incompatible with vitest forks pool (used by isolated config).
-// The retry logic is still tested in the main thread pool config.
-const describeRetry = isCoverageMode ? describe.skip : describe
-
-// oxlint-disable-next-line socket/require-vitest-globals-import -- describeRetry is a local const aliasing the imported describe (describe.skip in coverage mode), not a vitest global.
-describeRetry('SocketSdk - Retry Logic', () => {
+describe('SocketSdk - Retry Logic', () => {
   setupTestEnvironment()
 
   describe('Authentication Error Handling', () => {

--- a/test/repo/unit/socket-sdk-upload.test.mts
+++ b/test/repo/unit/socket-sdk-upload.test.mts
@@ -22,10 +22,7 @@ import {
   getFormData,
 } from '../../../src/file-upload.mts'
 import { SocketSdk } from '../../../src/index.mts'
-import {
-  isCoverageMode,
-  setupNockEnvironment,
-} from '../../utils/environment.mts'
+import { setupNockEnvironment } from '../../utils/environment.mts'
 import { FAST_TEST_CONFIG } from '../../utils/fast-test-config.mts'
 import { safeDelete } from '@socketsecurity/lib-stable/fs/safe'
 
@@ -139,6 +136,7 @@ describe('File Upload - createRequestBodyForFilepaths', () => {
 })
 
 describe('File Upload - createUploadRequest', () => {
+  setupNockEnvironment()
   let tempDir: string
 
   beforeEach(() => {
@@ -173,7 +171,7 @@ describe('File Upload - createUploadRequest', () => {
     expect(response.status).toBe(200)
   })
 
-  it.skipIf(isCoverageMode)('should call hooks when provided', async () => {
+  it('should call hooks when provided', async () => {
     let requestCalled = false
     let responseCalled = false
 
@@ -206,7 +204,7 @@ describe('File Upload - createUploadRequest', () => {
     expect(responseCalled).toBe(true)
   })
 
-  it.skipIf(isCoverageMode)('should handle upload errors', async () => {
+  it('should handle upload errors', async () => {
     const testFile = path.join(tempDir, 'test.txt')
     writeFileSync(testFile, 'test content')
 
@@ -226,7 +224,7 @@ describe('File Upload - createUploadRequest', () => {
     expect(response.status).toBe(400)
   })
 
-  it.skipIf(isCoverageMode)('should handle JSON body in request', async () => {
+  it('should handle JSON body in request', async () => {
     const FormDataCtor = getFormData()
     const jsonPart = new FormDataCtor()
     jsonPart.append(
@@ -252,36 +250,33 @@ describe('File Upload - createUploadRequest', () => {
     expect(response.status).toBe(200)
   })
 
-  it.skipIf(isCoverageMode)(
-    'should handle mixed file and JSON uploads',
-    async () => {
-      const testFile = path.join(tempDir, 'manifest.json')
-      writeFileSync(testFile, '{"dependencies":{}}')
+  it('should handle mixed file and JSON uploads', async () => {
+    const testFile = path.join(tempDir, 'manifest.json')
+    writeFileSync(testFile, '{"dependencies":{}}')
 
-      // Create a single FormData with both file and JSON
-      const form = createRequestBodyForFilepaths([testFile], tempDir)
-      const jsonStream = Readable.from(JSON.stringify({ metadata: 'test' }), {
-        highWaterMark: 1024 * 1024,
-      })
-      form.append('meta', jsonStream, {
-        contentType: 'application/json',
-        filename: 'meta.json',
-      })
+    // Create a single FormData with both file and JSON
+    const form = createRequestBodyForFilepaths([testFile], tempDir)
+    const jsonStream = Readable.from(JSON.stringify({ metadata: 'test' }), {
+      highWaterMark: 1024 * 1024,
+    })
+    form.append('meta', jsonStream, {
+      contentType: 'application/json',
+      filename: 'meta.json',
+    })
 
-      nock('https://api.socket.dev')
-        .post('/v0/test-mixed-upload')
-        .reply(200, { success: true })
+    nock('https://api.socket.dev')
+      .post('/v0/test-mixed-upload')
+      .reply(200, { success: true })
 
-      const response = await createUploadRequest(
-        'https://api.socket.dev',
-        '/v0/test-mixed-upload',
-        form,
-        { timeout: 5000 },
-      )
+    const response = await createUploadRequest(
+      'https://api.socket.dev',
+      '/v0/test-mixed-upload',
+      form,
+      { timeout: 5000 },
+    )
 
-      expect(response.status).toBe(200)
-    },
-  )
+    expect(response.status).toBe(200)
+  })
 
   it(
     'should handle network connection failures gracefully',

--- a/test/utils/environment.mts
+++ b/test/utils/environment.mts
@@ -11,10 +11,6 @@ import { SocketSdk } from '../../src/index.mts'
 
 import type { IncomingHttpHeaders } from 'node:http'
 
-// Check if running in coverage mode
-// This is set in vitest.config.mts when coverage is enabled
-export const isCoverageMode = process.env['COVERAGE'] === 'true'
-
 /**
  * Normalize a nock `scope.on('request')` payload's headers across nock majors:
  * nock 14 emits a legacy ClientRequest-shaped req whose `headers` is a plain
@@ -67,26 +63,18 @@ export function setupNockEnvironment() {
     nock.cleanAll()
     nock.activate()
     nock.disableNetConnect()
-
-    // In coverage mode, be extra aggressive about cleanup
-    if (isCoverageMode) {
-      nock.abortPendingRequests()
-      nock.cleanAll()
-    }
   })
 
   afterEach(() => {
-    // In coverage mode, be aggressive about cleanup
-    if (isCoverageMode) {
+    try {
+      if (!nock.isDone()) {
+        throw new Error(`pending nock mocks: ${nock.pendingMocks()}`)
+      }
+    } finally {
       nock.abortPendingRequests()
+      nock.cleanAll()
+      nock.restore()
     }
-
-    // Skip strict pending mock checks in coverage mode
-    if (!isCoverageMode && !nock.isDone()) {
-      throw new Error(`pending nock mocks: ${nock.pendingMocks()}`)
-    }
-    nock.cleanAll()
-    nock.restore()
   })
 }
 
@@ -127,35 +115,7 @@ export function setupTestClient(
 }
 
 export function setupTestEnvironment() {
-  beforeEach(() => {
-    nock.restore()
-    nock.cleanAll()
-    nock.activate()
-    nock.disableNetConnect()
-
-    // In coverage mode (singleThread: true), be extra aggressive about cleanup
-    // to prevent nock mock state bleeding between tests
-    if (isCoverageMode) {
-      nock.abortPendingRequests()
-      // Clear any lingering interceptors
-      nock.cleanAll()
-    }
-  })
-
-  afterEach(() => {
-    // In coverage mode, be aggressive about cleanup to prevent state bleeding
-    if (isCoverageMode) {
-      nock.abortPendingRequests()
-    }
-
-    // Skip strict pending mock checks in coverage mode
-    // The singleThread execution can cause timing issues with nock.isDone()
-    if (!isCoverageMode && !nock.isDone()) {
-      throw new Error(`pending nock mocks: ${nock.pendingMocks()}`)
-    }
-    nock.cleanAll()
-    nock.restore()
-  })
+  setupNockEnvironment()
 }
 
 // Handle unhandled rejections in tests.


### PR DESCRIPTION
## Changes

- Remove coverage-only exclusions from upload, optional-configuration, JSON error, retry, and rate-limit tests.
- Keep HTTP mock verification equally strict with and without coverage.
- Add the upload suite’s missing mock lifecycle setup, exposed by the normal repository runner.
- Share cleanup between the test environment helpers.

## Validation

- All 325 tests in the 27 shared-environment suites pass under coverage, with zero skips.
- All 325 also pass without coverage.
- Normal commit hooks pass: security, lint, and 49 staged tests.
- Normal push hooks pass, including type checking.
- No thresholds or coverage badge values were changed; the coverage measurement was scoped to the audited suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to mocks and helpers; production SDK code is untouched.
> 
> **Overview**
> **Enables nock-based HTTP, retry, upload, and JSON-error tests during coverage runs** by dropping `isCoverageMode` and every `it.skipIf` / `describe.skipIf` / `describeRetry` guard that used to skip them when `COVERAGE=true`.
> 
> **Tightens shared nock lifecycle:** `setupTestEnvironment()` now delegates to `setupNockEnvironment()`, which always fails tests on pending mocks and cleans up in a `try/finally`. Coverage-specific relaxed cleanup and duplicate hooks in `setupTestEnvironment` are removed. The `createUploadRequest` upload tests call `setupNockEnvironment()` so those cases get the same mock setup when the full suite runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f2444208a98fd37faf3e38b614983efc3a2ef15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->